### PR TITLE
로그인사용자 메인페이지

### DIFF
--- a/app/(login)/CategoryMenu.tsx
+++ b/app/(login)/CategoryMenu.tsx
@@ -1,0 +1,86 @@
+"use client";
+import Link from "next/link";
+import { useRef, useState } from "react";
+
+type Board = {
+  bbs_url: string;
+  bbs_name: string;
+};
+
+export default function CategoryMenu({ boardList }: { boardList: Board[] }) {
+  const [showContentLine, setShowContentLine] = useState(false);
+  const lineVariousRef = useRef<HTMLDivElement>(null);
+  return (
+    <>
+      <ul id="category">
+        <li
+          id="category_various"
+          className="category_content"
+          onMouseOver={() => setShowContentLine(true)}
+        >
+          <Link href="/board/2">게시판</Link>
+        </li>
+        <li
+          id="category_study"
+          className="category_content"
+          onMouseOver={() => setShowContentLine(false)}
+        >
+          <Link href="/study">스터디</Link>
+        </li>
+        <li
+          id="category_project"
+          className="category_content"
+          onMouseOver={() => setShowContentLine(false)}
+        >
+          <Link href="/projects">프로젝트</Link>
+        </li>
+        {/* TODO: why workshop and calendar do not hide content line */}
+        <li id="category_workshop" className="category_content">
+          <Link href="/workshops/0">워크샵</Link>
+        </li>
+        <li id="category_calendar" className="category_content">
+          <Link href="/calendar">일정</Link>
+        </li>
+      </ul>
+      <div id="content_line">
+        {showContentLine && (
+          <>
+            <div
+              id="nav_button_left"
+              onClick={() => {
+                if (lineVariousRef.current) {
+                  lineVariousRef.current.scrollLeft -= 200;
+                }
+              }}
+            >
+              ◁
+            </div>
+            <div id="line_various" ref={lineVariousRef}>
+              {boardList.map((board) => (
+                <span className="bar_separated" key={board.bbs_url}>
+                  <Link href={`/board/${board.bbs_url}`}>{board.bbs_name}</Link>
+                </span>
+              ))}
+              <span className="bar_separated">
+                <Link href="/purchases">지름게시판</Link>
+              </span>
+              <span className="bar_separated">
+                <Link href="/promotes">정회원 승격 신청</Link>
+              </span>
+            </div>
+            <div
+              id="nav_button_right"
+              onClick={() => {
+                if (lineVariousRef.current) {
+                  lineVariousRef.current.scrollLeft += 200;
+                }
+              }}
+            >
+              ▷
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/(login)/LogoutButton.tsx
+++ b/app/(login)/LogoutButton.tsx
@@ -5,9 +5,16 @@ import { useRouter } from "next/navigation";
 
 export default function LogoutButton() {
   const router = useRouter();
-  return <a href="/logout" onClick={async (e) => {
-    e.preventDefault();
-    await signOut();
-    router.push("/");
-  }}>로그아웃</a>
+  return (
+    <a
+      href="/logout"
+      onClick={async (e) => {
+        e.preventDefault();
+        await signOut();
+        router.push("/");
+      }}
+    >
+      로그아웃
+    </a>
+  );
 }

--- a/app/(login)/LogoutButton.tsx
+++ b/app/(login)/LogoutButton.tsx
@@ -1,17 +1,14 @@
 "use client";
 
 import { signOut } from "next-auth/react";
-import { useRouter } from "next/navigation";
 
 export default function LogoutButton() {
-  const router = useRouter();
   return (
     <a
       href="/logout"
       onClick={async (e) => {
         e.preventDefault();
-        await signOut();
-        router.push("/");
+        await signOut({ callbackUrl: "/" });
       }}
     >
       로그아웃

--- a/app/(login)/LogoutButton.tsx
+++ b/app/(login)/LogoutButton.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import { useRouter } from "next/navigation";
+
+export default function LogoutButton() {
+  const router = useRouter();
+  return <a href="/logout" onClick={async (e) => {
+    e.preventDefault();
+    await signOut();
+    router.push("/");
+  }}>로그아웃</a>
+}

--- a/app/(login)/layout.css
+++ b/app/(login)/layout.css
@@ -1,5 +1,13 @@
-*, span, a, button, input, textarea, div {
-  font-family: "나눔고딕", "NanumGothic", "맑은 고딕", "Malgun Gothic", "돋움", "Dotum", "애플고딕", "AppleGothic", "sans-serif";
+*,
+span,
+a,
+button,
+input,
+textarea,
+div {
+  font-family:
+    "나눔고딕", "NanumGothic", "맑은 고딕", "Malgun Gothic", "돋움", "Dotum",
+    "애플고딕", "AppleGothic", "sans-serif";
 }
 
 a {
@@ -64,17 +72,17 @@ a:visited {
 }
 
 #menu_user_gravatar {
-  width:32px;
-  height:32px;
-  float:left;
-  margin-right:10px;
+  width: 32px;
+  height: 32px;
+  float: left;
+  margin-right: 10px;
 }
 
 #menu_username {
-  float:left;
-  width:150px;
-  height:32px;
-  line-height:32px;
+  float: left;
+  width: 150px;
+  height: 32px;
+  line-height: 32px;
   text-align: left;
 }
 
@@ -109,12 +117,8 @@ a:visited {
   overflow: hidden;
 }
 
-#content_line span {
-  padding: 0px 6px;
-}
-
-#nav_button_left, #nav_button_right {
-  display: none;
+#nav_button_left,
+#nav_button_right {
   position: absolute;
   top: 5px;
   width: 30px;
@@ -141,7 +145,7 @@ a:visited {
   min-height: inherit;
   margin-right: 45px;
   margin-left: 45px;
-  display: none;
+  /* display: none; */
   line-height: 32px;
   white-space: nowrap;
   overflow: scroll;
@@ -187,7 +191,10 @@ a:visited {
   list-style-type: none;
 }
 
-#board_list, #workshop_list, #tagcloud, #promotion_board_list {
+#board_list,
+#workshop_list,
+#tagcloud,
+#promotion_board_list {
   margin-bottom: 20px;
 }
 
@@ -326,7 +333,7 @@ a:visited {
   text-align: center;
 }
 
-.search input[type=text] {
+.search input[type="text"] {
   width: 100%;
 }
 
@@ -338,16 +345,12 @@ a:visited {
   text-align: center;
 }
 
-#bottom_menu span {
-  padding: 0px 6px;
-}
-
 .about-commit {
   margin-top: 15px;
   text-align: right;
 }
 
-.is_new{
+.is_new {
   float: left;
 }
 

--- a/app/(login)/layout.css
+++ b/app/(login)/layout.css
@@ -59,10 +59,6 @@ a:visited {
   font-weight: bold;
 }
 
-#top_menu span {
-  padding: 0 4px;
-}
-
 #menu_user_info {
   float: right;
 }

--- a/app/(login)/layout.css
+++ b/app/(login)/layout.css
@@ -137,7 +137,7 @@ a:visited {
 #line_various {
   float: right;
   position: relative;
-  max-width: 900px;
+  max-width: 880px;
   min-height: inherit;
   margin-right: 45px;
   margin-left: 45px;

--- a/app/(login)/layout.css
+++ b/app/(login)/layout.css
@@ -355,3 +355,9 @@ a:visited {
   display: inline-block;
   text-align: center;
 }
+
+.bar_separated:not(:first-child)::before {
+  content: " | ";
+  margin: 1px;
+  opacity: 0.5;
+}

--- a/app/(login)/layout.tsx
+++ b/app/(login)/layout.tsx
@@ -2,35 +2,23 @@ import Link from "next/link";
 import Image from "next/image";
 import "./layout.css";
 import logo from "@/public/images/upnl.png";
-/*
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/chosen.min.css') }}">
-<script type="text/javascript" src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='ckeditor/ckeditor.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/Autolinker.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/chosen.jquery.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/common.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/typeahead.bundle.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/sisyphus.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/jquery.nanoscroller.min.js') }}"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/login/layout.js') }}"></script>
-    */
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
+import CategoryMenu from "./CategoryMenu";
 
 // from date.strftime('%Y/%m/%d %H:%M')
 // TODO: use dayjs
 function formatDate(date: Date) {
   return (
     date.getFullYear() +
-      "/" +
-      String(date.getMonth() + 1).padStart(2, "0") +
-      "/" +
-      String(date.getDate()).padStart(2, "0") +
-      " " +
-      String(date.getHours()).padStart(2, "0") +
-      ":" +
-      String(date.getMinutes()).padStart(2, "0")
+    "/" +
+    String(date.getMonth() + 1).padStart(2, "0") +
+    "/" +
+    String(date.getDate()).padStart(2, "0") +
+    " " +
+    String(date.getHours()).padStart(2, "0") +
+    ":" +
+    String(date.getMinutes()).padStart(2, "0")
   );
 }
 
@@ -40,8 +28,7 @@ export default async function LoginLayout({
   children: React.ReactNode;
 }>) {
   const session = await getServerSession();
-  if (!session)
-    redirect("/");
+  if (!session) redirect("/");
 
   /* TODO: data fetching */
   const user = {
@@ -54,120 +41,11 @@ export default async function LoginLayout({
     { bbs_url: "1", bbs_name: "공지사항" },
     { bbs_url: "2", bbs_name: "자유게시판" },
   ];
-  const allTagList = [
-    { no: 1, content: "tag1", count: 5 },
-    { no: 2, content: "tag2", count: 10 },
-  ];
-  const panoramaList = [
-    {
-      action: { value: "new-article" },
-      article: {
-        no: 1, title: "Test Article", bbs_name: "자유게시판", bbs_url: "2",
-        user: { no: 1, name: "Admin" },
-      },
-      actor: { no: 1, name: "Admin", email: "admin@example.com" },
-      date: new Date(),
-    },
-    {
-      action: { value: "new-comment" },
-      article: {
-        no: 1, title: "Test Article", bbs_name: "자유게시판", bbs_url: "2",
-        user: { no: 1, name: "Admin" },
-      },
-      actor: { no: 1, name: "Admin", email: "admin@example.com" },
-      date: new Date(),
-    },
-  ];
   const lastCommit = "abcdef";
   const lastCommitDate = new Date();
 
   // TODO: utilties
-  const tagLevel = (_count: number) => "";
-  const makeGravatarUrl = (_email: string, _size: number) => "https://example.com";
   const prettyDate = (date: Date) => formatDate(date);
-
-  // TODO: jinja blocks
-  const blockAddSidebar = null;
-  const blockSidebar = (
-    <div id="sidebar">
-      {blockAddSidebar}
-      <div id="tagcloud">
-        <div className="title_horizontal">
-          <h3>태그</h3>
-        </div>
-        <div className="content_horizontal">
-          <div id="tag_contents" className="nano">
-            <div className="nano-content">
-              {allTagList.map((tag) => (
-                <span className="bar_separated" key={tag.no}>
-                  <a className={tagLevel(tag.count)} href={`/tag/${tag.no}`}>
-                    {tag.content}
-                  </a>
-                </span>
-              ))}
-            </div>
-          </div>
-          <div id="tag_search" className="search">
-            <input id="tag_search_content" type="text"/>
-            <button id="tag_search_button">검색</button>
-          </div>
-          <div style={{clear: "both"}}></div>
-        </div>
-      </div>
-    </div>
-  );
-  const blockContents = children;
-  const blockPanorama = (
-    <>
-      <button id="panorama-wake-button">파노라마</button>
-      <div id="panorama">
-        <div className="title_horizontal">
-          <h3>파노라마</h3>
-        </div>
-        <div id="panorama_content" className="content_horizontal">
-          <div id="panorama_nano" className="nano">
-            <div id="panorama_nano_content" className="nano-content">
-              {panoramaList.map((panorama, index) => (
-                panorama.article === null ?
-                  <div className="panorama_row article" key={index}>
-                    <span>삭제된 게시글입니다.</span>
-                  </div>
-                  :
-                  <div className="panorama_row article" key={index}>
-                    <img src={makeGravatarUrl(panorama.actor.email, 32)} height="32px" />
-                    <div className="panorama-row-content">
-                      <Link href={`/${panorama.article.no}`}>
-                        {panorama.action.value === "new-article" ?
-                          `${panorama.actor.name} 님의 글 [${panorama.article.title}]이(가) 등록되었습니다.` :
-                          panorama.action.value === "new-comment" ?
-                          `${panorama.actor.name} 님이 글 [${panorama.article.title}]에 댓글을 다셨습니다.` :
-                          null
-                        }
-                      </Link>
-                      /
-                      {panorama.article.bbs_name === "지름게시판" ?
-                        (<>
-                          <Link href="/purchases" className="panorama_board">
-                            {panorama.article.bbs_name}
-                          </Link>
-                          <br />
-                        </>) :
-                          (<Link href={`/board/${panorama.article.bbs_url}`} className="panorama_board">
-                            {panorama.article.bbs_name}
-                          </Link>)
-                      }
-                      <span title={formatDate(panorama.date)} className="datatime">
-                        ({prettyDate(panorama.date)})
-                      </span>
-                    </div>
-                  </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-    </>
-  );
 
   return (
     <div id="body">
@@ -176,12 +54,14 @@ export default async function LoginLayout({
       <div id="header" className="default">
         <div id="top_menu" className="dark">
           <div id="menu_menu">
-            {user.id == 'admin' && (<>
-              <span>
-                <Link href="/admin">관리자 페이지</Link>
-              </span>
-              <span className="bar">|</span>
-            </>)}
+            {user.id == "admin" && (
+              <>
+                <span>
+                  <Link href="/admin">관리자 페이지</Link>
+                </span>
+                <span className="bar">|</span>
+              </>
+            )}
             <span>
               <Link href="/logout">로그아웃</Link>
             </span>
@@ -192,7 +72,7 @@ export default async function LoginLayout({
           </div>
           <div id="menu_user_info">
             <span id="menu_user_gravatar">
-              <img src={gravatarUrl}/>
+              <img src={gravatarUrl} />
             </span>
             <span id="menu_username">
               <Link href={`/user_info/${user.no}`}>{user.name}</Link>
@@ -209,73 +89,45 @@ export default async function LoginLayout({
             </h2>
           </div>
         </div>
-        <ul id="category">
-          <li id="category_various" className="category_content">
-            <Link href="/board/2">게시판</Link>
-          </li>
-          <li id="category_study" className="category_content">
-            <Link href="/study">스터디</Link>
-          </li>
-          <li id="category_project" className="category_content">
-            <Link href="/projects">프로젝트</Link>
-          </li>
-          <li id="category_workshop" className="category_content">
-            <Link href="/workshops/0">워크샵</Link>
-          </li>
-          <li id="category_calendar" className="category_content">
-            <Link href="/calendar">일정</Link>
-          </li>
-        </ul>
-        <div id="content_line">
-          <div id="nav_button_left">◁</div>
-          <div id="line_various">
-            {boardList.map((board) => (
-              <span className="bar_separated" key={board.bbs_url}>
-                <Link href={`/board/${board.bbs_url}`}>{board.bbs_name}</Link>
-              </span>
-            ))}
-            <span className="bar_separated"><Link href="/purchases">지름게시판</Link></span>
-            <span className="bar_separated"><Link href="/promotes">정회원 승격 신청</Link></span>
-          </div>
-          <div id="nav_button_right">▷</div>
-        </div>
+        <CategoryMenu boardList={boardList} />
       </div>
       {/*헤더끝*/}
-      <div id="middle" className="container backboard">
-        {blockSidebar}
-        <div id="main_contents">
-          {blockContents}
-        </div>
-        {blockPanorama}
-      </div>
+      {children}
       {/*푸터시작*/}
       <div id="bottom_menu" className="default dark">
-        <span><a href="https://github.com/upnl/upnl-homepage-next/issues">오류 신고 / 기능 제안</a></span>
-        <span className="bar">|</span>
-        <span>
+        <span className="bar_separated">
+          <a href="https://github.com/upnl/upnl-homepage-next/issues">
+            오류 신고 / 기능 제안
+          </a>
+        </span>
+        <span className="bar_separated">
           <Link href="/users">회원 정보</Link>
         </span>
-        <span className="bar">|</span>
-        <span>
+        <span className="bar_separated">
           <Link href="http://wiki.sodrak.upnl.org">위키</Link>
         </span>
-        <span className="bar">|</span>
-        <span>
+        <span className="bar_separated">
           <Link href="/panorama">파노라마</Link>
         </span>
-        <span className="bar">|</span>
-        <span>
+        <span className="bar_separated">
           {/* TODO: what is this? */}
           <Link href="/andromeda">안드로메다</Link>
         </span>
-        <span className="bar">|</span>
-        <span><Link href="/public/bylaw">UPnL 회칙</Link></span>
-        <span className="bar">|</span>
-        <Link href="/recent.atom">Atom</Link>
+        <span className="bar_separated">
+          <Link href="/public/bylaw">UPnL 회칙</Link>
+        </span>
+        <span className="bar_separated">
+          <Link href="/recent.atom">Atom</Link>
+        </span>
         <div className="about-commit">
           {lastCommit.length > 0 && (
             <span>
-              마지막 커밋: <Link href={`https://github.com/upnl/upnl-homepage-next/commit/${lastCommit}`}>{lastCommit.slice(0, 5)}</Link>
+              마지막 커밋:{" "}
+              <Link
+                href={`https://github.com/upnl/upnl-homepage-next/commit/${lastCommit}`}
+              >
+                {lastCommit.slice(0, 5)}
+              </Link>
               (최근 수정: {prettyDate(lastCommitDate)})
             </span>
           )}

--- a/app/(login)/layout.tsx
+++ b/app/(login)/layout.tsx
@@ -5,6 +5,7 @@ import logo from "@/public/images/upnl.png";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import CategoryMenu from "./CategoryMenu";
+import LogoutButton from "./LogoutButton";
 
 // from date.strftime('%Y/%m/%d %H:%M')
 // TODO: use dayjs
@@ -55,18 +56,14 @@ export default async function LoginLayout({
         <div id="top_menu" className="dark">
           <div id="menu_menu">
             {user.id == "admin" && (
-              <>
-                <span>
-                  <Link href="/admin">관리자 페이지</Link>
-                </span>
-                <span className="bar">|</span>
-              </>
+              <span className="bar_separated">
+                <Link href="/admin">관리자 페이지</Link>
+              </span>
             )}
-            <span>
-              <Link href="/logout">로그아웃</Link>
+            <span className="bar_separated">
+              <LogoutButton />
             </span>
-            <span className="bar">|</span>
-            <span>
+            <span className="bar_separated">
               <Link href={`/modify_user/${user.no}`}>정보 변경</Link>
             </span>
           </div>

--- a/app/(login)/layout.tsx
+++ b/app/(login)/layout.tsx
@@ -111,7 +111,7 @@ export default async function LoginLayout({
           <Link href="/andromeda">안드로메다</Link>
         </span>
         <span className="bar_separated">
-          <Link href="/public/bylaw">UPnL 회칙</Link>
+          <Link href="/bylaw">UPnL 회칙</Link>
         </span>
         <span className="bar_separated">
           <Link href="/recent.atom">Atom</Link>

--- a/app/(login)/layout.tsx
+++ b/app/(login)/layout.tsx
@@ -1,0 +1,286 @@
+import Link from "next/link";
+import Image from "next/image";
+import "./layout.css";
+import logo from "@/public/images/upnl.png";
+/*
+    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/chosen.min.css') }}">
+<script type="text/javascript" src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='ckeditor/ckeditor.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/Autolinker.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/chosen.jquery.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/common.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/typeahead.bundle.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/sisyphus.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/jquery.nanoscroller.min.js') }}"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/login/layout.js') }}"></script>
+    */
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+
+// from date.strftime('%Y/%m/%d %H:%M')
+// TODO: use dayjs
+function formatDate(date: Date) {
+  return (
+    date.getFullYear() +
+      "/" +
+      String(date.getMonth() + 1).padStart(2, "0") +
+      "/" +
+      String(date.getDate()).padStart(2, "0") +
+      " " +
+      String(date.getHours()).padStart(2, "0") +
+      ":" +
+      String(date.getMinutes()).padStart(2, "0")
+  );
+}
+
+export default async function LoginLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const session = await getServerSession();
+  if (!session)
+    redirect("/");
+
+  /* TODO: data fetching */
+  const user = {
+    id: "admin",
+    no: 1,
+    name: session.user?.name ?? "username",
+  };
+  const gravatarUrl = "https://example.com";
+  const boardList = [
+    { bbs_url: "1", bbs_name: "공지사항" },
+    { bbs_url: "2", bbs_name: "자유게시판" },
+  ];
+  const allTagList = [
+    { no: 1, content: "tag1", count: 5 },
+    { no: 2, content: "tag2", count: 10 },
+  ];
+  const panoramaList = [
+    {
+      action: { value: "new-article" },
+      article: {
+        no: 1, title: "Test Article", bbs_name: "자유게시판", bbs_url: "2",
+        user: { no: 1, name: "Admin" },
+      },
+      actor: { no: 1, name: "Admin", email: "admin@example.com" },
+      date: new Date(),
+    },
+    {
+      action: { value: "new-comment" },
+      article: {
+        no: 1, title: "Test Article", bbs_name: "자유게시판", bbs_url: "2",
+        user: { no: 1, name: "Admin" },
+      },
+      actor: { no: 1, name: "Admin", email: "admin@example.com" },
+      date: new Date(),
+    },
+  ];
+  const lastCommit = "abcdef";
+  const lastCommitDate = new Date();
+
+  // TODO: utilties
+  const tagLevel = (_count: number) => "";
+  const makeGravatarUrl = (_email: string, _size: number) => "https://example.com";
+  const prettyDate = (date: Date) => formatDate(date);
+
+  // TODO: jinja blocks
+  const blockAddSidebar = null;
+  const blockSidebar = (
+    <div id="sidebar">
+      {blockAddSidebar}
+      <div id="tagcloud">
+        <div className="title_horizontal">
+          <h3>태그</h3>
+        </div>
+        <div className="content_horizontal">
+          <div id="tag_contents" className="nano">
+            <div className="nano-content">
+              {allTagList.map((tag) => (
+                <span className="bar_separated" key={tag.no}>
+                  <a className={tagLevel(tag.count)} href={`/tag/${tag.no}`}>
+                    {tag.content}
+                  </a>
+                </span>
+              ))}
+            </div>
+          </div>
+          <div id="tag_search" className="search">
+            <input id="tag_search_content" type="text"/>
+            <button id="tag_search_button">검색</button>
+          </div>
+          <div style={{clear: "both"}}></div>
+        </div>
+      </div>
+    </div>
+  );
+  const blockContents = children;
+  const blockPanorama = (
+    <>
+      <button id="panorama-wake-button">파노라마</button>
+      <div id="panorama">
+        <div className="title_horizontal">
+          <h3>파노라마</h3>
+        </div>
+        <div id="panorama_content" className="content_horizontal">
+          <div id="panorama_nano" className="nano">
+            <div id="panorama_nano_content" className="nano-content">
+              {panoramaList.map((panorama, index) => (
+                panorama.article === null ?
+                  <div className="panorama_row article" key={index}>
+                    <span>삭제된 게시글입니다.</span>
+                  </div>
+                  :
+                  <div className="panorama_row article" key={index}>
+                    <img src={makeGravatarUrl(panorama.actor.email, 32)} height="32px" />
+                    <div className="panorama-row-content">
+                      <Link href={`/${panorama.article.no}`}>
+                        {panorama.action.value === "new-article" ?
+                          `${panorama.actor.name} 님의 글 [${panorama.article.title}]이(가) 등록되었습니다.` :
+                          panorama.action.value === "new-comment" ?
+                          `${panorama.actor.name} 님이 글 [${panorama.article.title}]에 댓글을 다셨습니다.` :
+                          null
+                        }
+                      </Link>
+                      /
+                      {panorama.article.bbs_name === "지름게시판" ?
+                        (<>
+                          <Link href="/purchases" className="panorama_board">
+                            {panorama.article.bbs_name}
+                          </Link>
+                          <br />
+                        </>) :
+                          (<Link href={`/board/${panorama.article.bbs_url}`} className="panorama_board">
+                            {panorama.article.bbs_name}
+                          </Link>)
+                      }
+                      <span title={formatDate(panorama.date)} className="datatime">
+                        ({prettyDate(panorama.date)})
+                      </span>
+                    </div>
+                  </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+
+  return (
+    <div id="body">
+      <h1 id="club_title">UPnL Homepage</h1>
+      {/* TODO: show '회원 정보가 변경되었습니다.' message on info changed */}
+      <div id="header" className="default">
+        <div id="top_menu" className="dark">
+          <div id="menu_menu">
+            {user.id == 'admin' && (<>
+              <span>
+                <Link href="/admin">관리자 페이지</Link>
+              </span>
+              <span className="bar">|</span>
+            </>)}
+            <span>
+              <Link href="/logout">로그아웃</Link>
+            </span>
+            <span className="bar">|</span>
+            <span>
+              <Link href={`/modify_user/${user.no}`}>정보 변경</Link>
+            </span>
+          </div>
+          <div id="menu_user_info">
+            <span id="menu_user_gravatar">
+              <img src={gravatarUrl}/>
+            </span>
+            <span id="menu_username">
+              <Link href={`/user_info/${user.no}`}>{user.name}</Link>
+            </span>
+          </div>
+        </div>
+        <div id="logo">
+          <Link href="/main">
+            <Image src={logo} width={158} height={49} alt="images/upnl.png" />
+          </Link>
+          <div className="hide">
+            <h2>
+              <Link href="/main">UPnL</Link>
+            </h2>
+          </div>
+        </div>
+        <ul id="category">
+          <li id="category_various" className="category_content">
+            <Link href="/board/2">게시판</Link>
+          </li>
+          <li id="category_study" className="category_content">
+            <Link href="/study">스터디</Link>
+          </li>
+          <li id="category_project" className="category_content">
+            <Link href="/projects">프로젝트</Link>
+          </li>
+          <li id="category_workshop" className="category_content">
+            <Link href="/workshops/0">워크샵</Link>
+          </li>
+          <li id="category_calendar" className="category_content">
+            <Link href="/calendar">일정</Link>
+          </li>
+        </ul>
+        <div id="content_line">
+          <div id="nav_button_left">◁</div>
+          <div id="line_various">
+            {boardList.map((board) => (
+              <span className="bar_separated" key={board.bbs_url}>
+                <Link href={`/board/${board.bbs_url}`}>{board.bbs_name}</Link>
+              </span>
+            ))}
+            <span className="bar_separated"><Link href="/purchases">지름게시판</Link></span>
+            <span className="bar_separated"><Link href="/promotes">정회원 승격 신청</Link></span>
+          </div>
+          <div id="nav_button_right">▷</div>
+        </div>
+      </div>
+      {/*헤더끝*/}
+      <div id="middle" className="container backboard">
+        {blockSidebar}
+        <div id="main_contents">
+          {blockContents}
+        </div>
+        {blockPanorama}
+      </div>
+      {/*푸터시작*/}
+      <div id="bottom_menu" className="default dark">
+        <span><a href="https://github.com/upnl/upnl-homepage-next/issues">오류 신고 / 기능 제안</a></span>
+        <span className="bar">|</span>
+        <span>
+          <Link href="/users">회원 정보</Link>
+        </span>
+        <span className="bar">|</span>
+        <span>
+          <Link href="http://wiki.sodrak.upnl.org">위키</Link>
+        </span>
+        <span className="bar">|</span>
+        <span>
+          <Link href="/panorama">파노라마</Link>
+        </span>
+        <span className="bar">|</span>
+        <span>
+          {/* TODO: what is this? */}
+          <Link href="/andromeda">안드로메다</Link>
+        </span>
+        <span className="bar">|</span>
+        <span><Link href="/public/bylaw">UPnL 회칙</Link></span>
+        <span className="bar">|</span>
+        <Link href="/recent.atom">Atom</Link>
+        <div className="about-commit">
+          {lastCommit.length > 0 && (
+            <span>
+              마지막 커밋: <Link href={`https://github.com/upnl/upnl-homepage-next/commit/${lastCommit}`}>{lastCommit.slice(0, 5)}</Link>
+              (최근 수정: {prettyDate(lastCommitDate)})
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(login)/main/page.css
+++ b/app/(login)/main/page.css
@@ -105,7 +105,7 @@
   white-space: nowrap;
 }
 
-.purchase_row>span {
+.purchase_row > span {
   margin-left: 10px;
 }
 
@@ -125,7 +125,7 @@
   line-height: 30px;
 }
 
-.promote_row>span {
+.promote_row > span {
   margin-left: 10px;
 }
 
@@ -149,7 +149,7 @@
 }
 
 #main_users_activities .content_horizontal {
-  width: ;
+  width:;
   height: 285px;
   box-sizing: border-box;
   padding: 5px;
@@ -167,7 +167,6 @@
   margin: 0;
   line-height: 18px;
   font-size: 16px;
-
 }
 
 .project_row_content {

--- a/app/(login)/main/page.tsx
+++ b/app/(login)/main/page.tsx
@@ -1,3 +1,316 @@
+import {
+  Container,
+  MainAlone,
+  Panorama,
+  TagCloud,
+} from "@/components/internalTemplates";
+import Link from "next/link";
+import "@/public/css/border_text.css";
+import "./page.css";
+
+/*
+ * TODO: use dayjs
+ * date.strftime('%m/%d')
+ */
+function formatDate(date: Date) {
+  return (
+    String(date.getMonth() + 1).padStart(2, "0") +
+    "/" +
+    String(date.getDate()).padStart(2, "0")
+  );
+}
+
+/*
+ * TODO: use dayjs
+ * date.strftime('%Y.%m.%d')
+ */
+function formatWorkshopDate(date: Date) {
+  return (
+    date.getFullYear() +
+    "." +
+    String(date.getMonth() + 1).padStart(2, "0") +
+    "." +
+    String(date.getDate()).padStart(2, "0")
+  );
+}
+
+function isNew(date: Date) {
+  // TODO
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const diffHours = Math.floor(diff / (1000 * 60 * 60));
+  return diffHours < 24;
+}
+
 export default async function LoginIndex() {
-  return null;
+  const articles_notice = [
+    {
+      no: 1,
+      date: new Date(),
+      title: "공지사항 제목",
+      comment: [],
+    },
+    {
+      no: 2,
+      date: new Date(),
+      title: "공지사항 제목2",
+      comment: [],
+    },
+  ];
+  const articles_free = [
+    {
+      no: 3,
+      date: new Date(),
+      title: "자유게시판 제목",
+      comment: [],
+    },
+    {
+      no: 4,
+      date: new Date(),
+      title: "자유게시판 제목2",
+      comment: [],
+    },
+  ];
+  const purchase_list = [
+    {
+      no: 5,
+      article: {
+        no: 5,
+        date: new Date(),
+        title: "지름게시판 제목",
+      },
+      product_name: "제품명",
+      assenter: [],
+    },
+    {
+      no: 6,
+      article: {
+        no: 6,
+        date: new Date(),
+        title: "지름게시판 제목2",
+      },
+      product_name: "제품명2",
+      assenter: [],
+    },
+  ];
+  const promote_list = [
+    {
+      requester_name: "요청자 이름",
+      assenter: [],
+      bbs_url: 7,
+    },
+    {
+      requester_name: "요청자 이름2",
+      assenter: [],
+      bbs_url: 8,
+    },
+  ];
+  const articles_project = [
+    {
+      no: 9,
+      bbs_name: "프로젝트 이름",
+      date: new Date(),
+      comment: [],
+      title: "제목",
+    },
+  ];
+  const workshop_portion = [
+    {
+      nth: 1,
+      start_date: new Date(),
+      sessions: [
+        {
+          no: 1,
+          title: "세션 제목",
+        },
+        {
+          no: 2,
+          title: "세션 제목2",
+        },
+      ],
+    },
+  ];
+  const required = 5;
+  return (
+    <Container>
+      <MainAlone>
+        <div id="main_new_articles" className="container nonedeco">
+          <div className="title_horizontal">
+            <h3>최신 글</h3>
+          </div>
+          <div id="main_notice" className="content_horizontal">
+            <h4 id="main_notice_title">
+              <Link href="/board/1">공지사항</Link>
+            </h4>
+            <div id="main_notice_contents" className="nano">
+              <div id="main_notice_nano_content" className="nano-content">
+                {articles_notice.map((article) => (
+                  <div className="article_row" key={article.no}>
+                    <span className="date">{formatDate(article.date)}</span>
+                    <div className="article_row_content">
+                      <span className="article_title">
+                        <Link href={`/${article.no}`}>{article.title}</Link>
+                      </span>
+                      {article.comment.length !== 0 && (
+                        <span className="comment">
+                          [{article.comment.length}]
+                        </span>
+                      )}
+                      <span className="is_new">
+                        {isNew(article.date) && "★"}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div id="main_freeboard" className="content_horizontal">
+            <h4 id="main_freeboard_title">
+              <Link href="/board/2">자유게시판</Link>
+            </h4>
+            <div id="main_freeboard_contents" className="nano">
+              <div id="main_freeboard_nano_content" className="nano-content">
+                {articles_free.map((article) => (
+                  <div className="article_row" key={article.no}>
+                    <span className="date">{formatDate(article.date)}</span>
+                    <div className="article_row_content">
+                      <span className="article_title">
+                        <Link href={`/${article.no}`}>{article.title}</Link>
+                      </span>
+                      {article.comment.length !== 0 && (
+                        <span className="comment">
+                          [{article.comment.length}]
+                        </span>
+                      )}
+                      <span className="is_new">
+                        {isNew(article.date) && "★"}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div id="main_purchase" className="content_horizontal">
+            <h4 className="main_purchase_title">
+              <Link href="/purchases" className="main_purchase_title">
+                지름게시판
+              </Link>
+            </h4>
+            <div id="main_purchase_contents" className="nano">
+              <div id="main_purchase_nano_content" className="nano-content">
+                {purchase_list.map((purchase) => (
+                  <div className="purchase_row article" key={purchase.no}>
+                    <span className="date">
+                      {formatDate(purchase.article.date)}
+                    </span>
+                    <span className="purchase_row_title">
+                      <Link href={`/${purchase.article.no}`}>
+                        {purchase.article.title}
+                      </Link>
+                    </span>
+                    <span className="num_agree">
+                      {" "}
+                      - 동의 수 : {purchase.assenter.length} / {required}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div id="main_promote" className="content_horizontal">
+            <h4 id="main_promote_title">
+              <Link href="/promotes">승격게시판</Link>
+            </h4>
+            <div id="main_promote_contents" className="nano">
+              <div id="main_promote_nano_content" className="nano-content">
+                {promote_list.map((promote) => (
+                  <div className="promote_row article" key={promote.bbs_url}>
+                    <span className="promote_row_title">
+                      <Link href={`/board/${promote.bbs_url}`}>
+                        {promote.requester_name}
+                      </Link>
+                    </span>
+                    <span className="num_agree">
+                      {" "}
+                      - 동의 수 : {promote.assenter.length} / {required}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="main_users_activities" className="nonedeco">
+          <div className="title_horizontal">
+            <h3 id="main_user_activities_title">참여 중인 프로젝트 & 스터디</h3>
+          </div>
+          <div className="content_horizontal">
+            <div id="main_user_activities_contents" className="nano">
+              <div
+                id="main_user_activities_nano_content"
+                className="nano-content"
+              >
+                {articles_project.map((article) => (
+                  <div
+                    className="project_article container article"
+                    key={article.no}
+                  >
+                    <h4>{article.bbs_name}</h4>
+                    <span className="date">{formatDate(article.date)}</span>
+                    <div className="project_row_content">
+                      <span className="project_title">
+                        <Link href={`/${article.no}`}>{article.title}</Link>
+                      </span>
+                      {article.comment.length !== 0 && (
+                        <span className="comment">
+                          [{article.comment.length}]
+                        </span>
+                      )}
+                      <span className="is_new">
+                        {isNew(article.date) && "★"}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+        <TagCloud />
+        <div id="workshop">
+          <div className="title_vertical">
+            <h3>워크샵</h3>
+          </div>
+          {workshop_portion.map((workshop) => (
+            <div className="content_vertical" key={workshop.nth}>
+              <div className="workshop_title">
+                <h4>
+                  <Link href={`/workshops/${workshop.nth}`}>
+                    {workshop.nth}차 워크샵
+                  </Link>
+                </h4>
+              </div>
+              <div className="workshop_datatime">
+                {formatWorkshopDate(workshop.start_date)}
+              </div>
+              <div className="workshop_about nano">
+                <div className="nano-content">
+                  {workshop.sessions
+                    .filter((session) => session.title !== "")
+                    .map((session) => (
+                      <div className="session_title" key={session.no}>
+                        {session.title}
+                      </div>
+                    ))}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </MainAlone>
+      <Panorama />
+    </Container>
+  );
 }

--- a/app/(login)/main/page.tsx
+++ b/app/(login)/main/page.tsx
@@ -43,6 +43,7 @@ function isNew(date: Date) {
 }
 
 export default async function LoginIndex() {
+  // TODO: fetch data from database
   const articles_notice = [
     {
       no: 1,

--- a/app/(login)/main/page.tsx
+++ b/app/(login)/main/page.tsx
@@ -1,9 +1,4 @@
-import {
-  Container,
-  MainAlone,
-  Panorama,
-  TagCloud,
-} from "@/components/internalTemplates";
+import { Container, MainAlone, Panorama } from "@/components/internalTemplates";
 import Link from "next/link";
 import "@/public/css/border_text.css";
 import "./page.css";
@@ -131,6 +126,11 @@ export default async function LoginIndex() {
       ],
     },
   ];
+  const allTagList = [
+    { no: 1, content: "tag1", count: 5 },
+    { no: 2, content: "tag2", count: 10 },
+  ];
+  const tagLevel = (_count: number) => "";
   const required = 5;
   return (
     <Container>
@@ -279,7 +279,32 @@ export default async function LoginIndex() {
             </div>
           </div>
         </div>
-        <TagCloud />
+        <div id="tagcloud">
+          <div className="title_horizontal">
+            <h3>태그</h3>
+          </div>
+          <div className="content_horizontal">
+            <div id="tag_contents" className="nano">
+              <div className="nano-content">
+                {allTagList.map((tag) => (
+                  <span className="bar_separated" key={tag.no}>
+                    <Link
+                      className={tagLevel(tag.count)}
+                      href={`/tag/${tag.no}`}
+                    >
+                      {tag.content}
+                    </Link>
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div id="tag_search" className="search">
+              <input id="tag_search_content" type="text" />
+              <button id="tag_search_button">검색</button>
+            </div>
+            <div style={{ clear: "both" }}></div>
+          </div>
+        </div>
         <div id="workshop">
           <div className="title_vertical">
             <h3>워크샵</h3>

--- a/app/(login)/main/page.tsx
+++ b/app/(login)/main/page.tsx
@@ -1,0 +1,3 @@
+export default async function LoginIndex() {
+  return null;
+}

--- a/app/(unlogin)/layout.css
+++ b/app/(unlogin)/layout.css
@@ -1,5 +1,13 @@
-*, span, a, button, input, textarea, div {
-  font-family: "나눔고딕", "NanumGothic", "맑은 고딕", "Malgun Gothic", "돋움", "Dotum", "애플고딕", "AppleGothic", "sans-serif";
+*,
+span,
+a,
+button,
+input,
+textarea,
+div {
+  font-family:
+    "나눔고딕", "NanumGothic", "맑은 고딕", "Malgun Gothic", "돋움", "Dotum",
+    "애플고딕", "AppleGothic", "sans-serif";
 }
 
 a {
@@ -20,7 +28,7 @@ a:visited {
 }
 
 .default {
-  margin:0px 0px 0px 0px;
+  margin: 0px 0px 0px 0px;
 }
 
 #club_title {

--- a/app/(unlogin)/page.tsx
+++ b/app/(unlogin)/page.tsx
@@ -1,6 +1,8 @@
 import { Fragment } from "react";
 import Link from "next/link";
 import "./index.css";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
 
 // from date.strftime('%Y.%m.%d')
 // TODO: use dayjs
@@ -15,6 +17,9 @@ function formatDate(date: Date) {
 }
 
 export default async function Index() {
+  const session = await getServerSession();
+  if (session) redirect("/main");
+
   // TODO: get data from database
   const mainContent = null;
   const tags = [

--- a/app/(unlogin)/public/login/login.css
+++ b/app/(unlogin)/public/login/login.css
@@ -2,12 +2,13 @@
   width: 970px;
 }
 
-#login_title{
+#login_title {
   width: 520px;
   margin: 190px auto 10px auto;
 }
 
-#login_title h2, #login_title h3 {
+#login_title h2,
+#login_title h3 {
   line-height: 30px;
   font-weight: normal;
 }
@@ -15,14 +16,14 @@
 #upnl {
   float: left;
   margin: 0;
-  color: #FFFFFF;
+  color: #ffffff;
   line-height: 30px;
   font-size: 30px;
 }
 
 #openyourdream {
   margin: 0;
-  color: #FFFFFF;
+  color: #ffffff;
   line-height: 30px;
   font-size: 20px;
 }
@@ -36,28 +37,27 @@
 }
 
 #login_form {
-  
 }
 
-#login_form  .control-group {
+#login_form .control-group {
   width: 330px;
   margin-bottom: 20px;
 }
 
-#login_form  .controls {
+#login_form .controls {
   float: left;
   margin-left: 0px;
 }
 
-#login_form  .controls input {
+#login_form .controls input {
   width: 330px;
   height: 30px;
-  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 #login_left {
   float: left;
-  width: 360px
+  width: 360px;
 }
 
 #login_right {

--- a/app/default.css
+++ b/app/default.css
@@ -1,5 +1,6 @@
-body { /*Background*/
-  background-color:#2a2a2a;
+body {
+  /*Background*/
+  background-color: #2a2a2a;
 }
 
 #logo {
@@ -15,7 +16,7 @@ body { /*Background*/
 }
 
 #category a {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 #category a:hover {
@@ -32,7 +33,7 @@ body { /*Background*/
 }
 
 #content_line a:hover {
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #434343;
 }
 
@@ -40,9 +41,11 @@ body { /*Background*/
   color: #a3a3a3;
 }
 
-#body button, #body input[type=button], #body a.button {
+#body button,
+#body input[type="button"],
+#body a.button {
   border: 1px solid black;
-  color: #FFFFFF;
+  color: #ffffff;
   background: #454545;
   font-weight: bold;
   box-shadow: none;
@@ -52,7 +55,10 @@ body { /*Background*/
   background-color: #888888;
 }
 
-#body input, #body textarea, #body select, #body .input {
+#body input,
+#body textarea,
+#body select,
+#body .input {
   border-radius: 0;
   background: #bcbcbc;
   box-shadow: inset 0px 0px 10px rgba(256, 256, 190, 0.43);
@@ -91,7 +97,7 @@ body { /*Background*/
 }
 
 #body .light a:hover {
-  color: #FFFFFF;
+  color: #ffffff;
   background: #9d9d9d;
 }
 
@@ -113,7 +119,7 @@ body { /*Background*/
 .title_horizontal {
   background-color: #454545;
   box-shadow: 1px 1px 1px black;
-  color: #FFFFFF;
+  color: #ffffff;
   font-weight: bold;
 }
 
@@ -127,14 +133,14 @@ body { /*Background*/
 }
 
 .content_horizontal a:hover {
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #6d6d6d;
 }
 
 .title_vertical {
   background-color: #454545;
   box-shadow: 1px 1px 1px black;
-  color: #FFFFFF;
+  color: #ffffff;
   font-weight: bold;
 }
 
@@ -148,12 +154,12 @@ body { /*Background*/
 }
 
 .content_vertical a:hover {
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: #6d6d6d;
 }
 
 #body .filelink:hover {
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: inherit;
 }
 
@@ -162,7 +168,7 @@ body { /*Background*/
 }
 
 .list tr th {
-  background-color:#bcbcbc;
+  background-color: #bcbcbc;
 }
 
 .list tr td {
@@ -177,16 +183,24 @@ body { /*Background*/
   box-shadow: none;
 }
 
-.chosen-container-multi .chosen-choices, .chosen-container-multi .chosen-results, .chosen-container-single .chosen-single, .chosen-container-single .chosen-drop {
+.chosen-container-multi .chosen-choices,
+.chosen-container-multi .chosen-results,
+.chosen-container-single .chosen-single,
+.chosen-container-single .chosen-drop {
   background: #bcbcbc;
 }
 
-.chosen-container-single .chosen-single, .chosen-container-single .chosen-drop, .chosen-container-multi .chosen-choices, .chosen-container-active .chosen-choices, .chosen-container.chosen-with-drop .chosen-drop {
+.chosen-container-single .chosen-single,
+.chosen-container-single .chosen-drop,
+.chosen-container-multi .chosen-choices,
+.chosen-container-active .chosen-choices,
+.chosen-container.chosen-with-drop .chosen-drop {
   background: #bcbcbc;
   border-radius: 0;
 }
 
-#tag table.list, .list2 {
+#tag table.list,
+.list2 {
   background: #bcbcbc;
 }
 
@@ -194,17 +208,18 @@ body { /*Background*/
   background: #bcbcbc;
 }
 
-#tag table.list tr th, .list2 tr th {
-  background-color:#F1F1F1;
-  border:2px solid;
+#tag table.list tr th,
+.list2 tr th {
+  background-color: #f1f1f1;
+  border: 2px solid;
 }
 
 table * {
-  border-color: #9d9d9d!important;
+  border-color: #9d9d9d !important;
 }
 
 .session_content a:hover {
-  color: #FFFFFF;
+  color: #ffffff;
   background-color: inherit;
 }
 

--- a/app/nanoscroller.css
+++ b/app/nanoscroller.css
@@ -1,18 +1,18 @@
 /** initial setup **/
 .nano {
-  position : relative;
-  width    : 100%;
-  height   : 100%;
-  overflow : hidden;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 .nano > .nano-content {
-  position      : absolute;
-  overflow      : scroll;
-  overflow-x    : hidden;
-  top           : 0;
-  right         : 0;
-  bottom        : 0;
-  left          : 0;
+  position: absolute;
+  overflow: scroll;
+  overflow-x: hidden;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 }
 .nano > .nano-content:focus {
   outline: thin dotted;
@@ -24,32 +24,34 @@
   display: block;
 }
 .nano > .nano-pane {
-  background : rgba(0,0,0,.25);
-  position   : absolute;
-  width      : 10px;
-  right      : 0;
-  top        : 0;
-  bottom     : 0;
-  visibility : hidden\9; /* Target only IE7 and IE8 with this hack */
-  opacity    : .01;
-  -webkit-transition    : .2s;
-  -moz-transition       : .2s;
-  -o-transition         : .2s;
-  transition            : .2s;
-  -moz-border-radius    : 5px;
-  -webkit-border-radius : 5px;
-  border-radius         : 5px;
+  background: rgba(0, 0, 0, 0.25);
+  position: absolute;
+  width: 10px;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  visibility: hidden\9; /* Target only IE7 and IE8 with this hack */
+  opacity: 0.01;
+  -webkit-transition: 0.2s;
+  -moz-transition: 0.2s;
+  -o-transition: 0.2s;
+  transition: 0.2s;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
 }
 .nano > .nano-pane > .nano-slider {
   background: #444;
-  background: rgba(0,0,0,.5);
-  position              : relative;
-  margin                : 0 1px;
-  -moz-border-radius    : 3px;
-  -webkit-border-radius : 3px;
-  border-radius         : 3px;
+  background: rgba(0, 0, 0, 0.5);
+  position: relative;
+  margin: 0 1px;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
 }
-.nano:hover > .nano-pane, .nano-pane.active, .nano-pane.flashed {
-  visibility : visible\9; /* Target only IE7 and IE8 with this hack */
-  opacity    : 0.99;
+.nano:hover > .nano-pane,
+.nano-pane.active,
+.nano-pane.flashed {
+  visibility: visible\9; /* Target only IE7 and IE8 with this hack */
+  opacity: 0.99;
 }

--- a/components/internalTemplates.tsx
+++ b/components/internalTemplates.tsx
@@ -1,0 +1,187 @@
+/*
+  in page.tsx, return like this:
+  return (
+    <Container>
+      <SideBar>
+        ...add_sidebar
+        <TagCloud/>
+      </SideBar>
+      <Main>
+        ...contents
+      </Main>
+      <Panorama/>
+    </Container>
+  );
+
+  or, if no sidebar:
+  return (
+    <Container>
+      <MainAlone>
+        ...contents
+      </MainAlone>
+      <Panorama/>
+    </Container>
+  );
+*/
+
+import Link from "next/link";
+
+export function Container({ children }: { children: React.ReactNode }) {
+  return (
+    <div id="middle" className="container backboard">
+      {children}
+    </div>
+  );
+}
+
+export function Main({ children }: { children: React.ReactNode }) {
+  return (
+    <div id="main_contents">
+      {children}
+    </div>
+  );
+}
+
+export function MainAlone({ children }: { children: React.ReactNode }) {
+  return (
+    <div id="main_contents" style={{ width: 940, marginLeft: 15 }}>
+      {children}
+    </div>
+  );
+}
+
+export function SideBar({ children }: { children: React.ReactNode }) {
+  return (
+    <div id="sidebar">
+      {children}
+    </div>
+  );
+}
+
+export async function TagCloud() {
+  // TODO: fetch allTagList from database
+  const allTagList = [
+    { no: 1, content: "tag1", count: 5 },
+    { no: 2, content: "tag2", count: 10 },
+  ];
+  const tagLevel = (_count: number) => "";
+  return (
+    <div id="tagcloud">
+      <div className="title_horizontal">
+        <h3>태그</h3>
+      </div>
+      <div className="content_horizontal">
+        <div id="tag_contents" className="nano">
+          <div className="nano-content">
+            {allTagList.map((tag) => (
+              <span className="bar_separated" key={tag.no}>
+                <a className={tagLevel(tag.count)} href={`/tag/${tag.no}`}>
+                  {tag.content}
+                </a>
+              </span>
+            ))}
+          </div>
+        </div>
+        <div id="tag_search" className="search">
+          <input id="tag_search_content" type="text"/>
+          <button id="tag_search_button">검색</button>
+        </div>
+        <div style={{clear: "both"}}></div>
+      </div>
+    </div>
+  );
+}
+
+// from date.strftime('%Y/%m/%d %H:%M')
+// TODO: use dayjs
+function formatDate(date: Date) {
+  return (
+    date.getFullYear() +
+      "/" +
+      String(date.getMonth() + 1).padStart(2, "0") +
+      "/" +
+      String(date.getDate()).padStart(2, "0") +
+      " " +
+      String(date.getHours()).padStart(2, "0") +
+      ":" +
+      String(date.getMinutes()).padStart(2, "0")
+  );
+}
+
+
+export async function Panorama() {
+  // TODO: fetch panoramaList from database
+  const panoramaList = [
+    {
+      action: { value: "new-article" },
+      article: {
+        no: 1, title: "Test Article", bbs_name: "자유게시판", bbs_url: "2",
+        user: { no: 1, name: "Admin" },
+      },
+      actor: { no: 1, name: "Admin", email: "admin@example.com" },
+      date: new Date(),
+    },
+    {
+      action: { value: "new-comment" },
+      article: {
+        no: 1, title: "Test Article", bbs_name: "자유게시판", bbs_url: "2",
+        user: { no: 1, name: "Admin" },
+      },
+      actor: { no: 1, name: "Admin", email: "admin@example.com" },
+      date: new Date(),
+    },
+  ];
+  const makeGravatarUrl = (_email: string, _size: number) => "https://example.com";
+  const prettyDate = (date: Date) => formatDate(date);
+  return (
+    <>
+      <button id="panorama-wake-button">파노라마</button>
+      <div id="panorama">
+        <div className="title_horizontal">
+          <h3>파노라마</h3>
+        </div>
+        <div id="panorama_content" className="content_horizontal">
+          <div id="panorama_nano" className="nano">
+            <div id="panorama_nano_content" className="nano-content">
+              {panoramaList.map((panorama, index) => (
+                panorama.article === null ?
+                  <div className="panorama_row article" key={index}>
+                    <span>삭제된 게시글입니다.</span>
+                  </div>
+                  :
+                  <div className="panorama_row article" key={index}>
+                    <img src={makeGravatarUrl(panorama.actor.email, 32)} height="32px" />
+                    <div className="panorama-row-content">
+                      <Link href={`/${panorama.article.no}`}>
+                        {panorama.action.value === "new-article" ?
+                          `${panorama.actor.name} 님의 글 [${panorama.article.title}]이(가) 등록되었습니다.` :
+                          panorama.action.value === "new-comment" ?
+                          `${panorama.actor.name} 님이 글 [${panorama.article.title}]에 댓글을 다셨습니다.` :
+                          null
+                        }
+                      </Link>
+                      /
+                      {panorama.article.bbs_name === "지름게시판" ?
+                        (<>
+                          <Link href="/purchases" className="panorama_board">
+                            {panorama.article.bbs_name}
+                          </Link>
+                          <br />
+                        </>) :
+                          (<Link href={`/board/${panorama.article.bbs_url}`} className="panorama_board">
+                            {panorama.article.bbs_name}
+                          </Link>)
+                      }
+                      <span title={formatDate(panorama.date)} className="datatime">
+                        ({prettyDate(panorama.date)})
+                      </span>
+                    </div>
+                  </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/internalTemplates.tsx
+++ b/components/internalTemplates.tsx
@@ -35,11 +35,7 @@ export function Container({ children }: { children: React.ReactNode }) {
 }
 
 export function Main({ children }: { children: React.ReactNode }) {
-  return (
-    <div id="main_contents">
-      {children}
-    </div>
-  );
+  return <div id="main_contents">{children}</div>;
 }
 
 export function MainAlone({ children }: { children: React.ReactNode }) {
@@ -51,45 +47,7 @@ export function MainAlone({ children }: { children: React.ReactNode }) {
 }
 
 export function SideBar({ children }: { children: React.ReactNode }) {
-  return (
-    <div id="sidebar">
-      {children}
-    </div>
-  );
-}
-
-export async function TagCloud() {
-  // TODO: fetch allTagList from database
-  const allTagList = [
-    { no: 1, content: "tag1", count: 5 },
-    { no: 2, content: "tag2", count: 10 },
-  ];
-  const tagLevel = (_count: number) => "";
-  return (
-    <div id="tagcloud">
-      <div className="title_horizontal">
-        <h3>태그</h3>
-      </div>
-      <div className="content_horizontal">
-        <div id="tag_contents" className="nano">
-          <div className="nano-content">
-            {allTagList.map((tag) => (
-              <span className="bar_separated" key={tag.no}>
-                <a className={tagLevel(tag.count)} href={`/tag/${tag.no}`}>
-                  {tag.content}
-                </a>
-              </span>
-            ))}
-          </div>
-        </div>
-        <div id="tag_search" className="search">
-          <input id="tag_search_content" type="text"/>
-          <button id="tag_search_button">검색</button>
-        </div>
-        <div style={{clear: "both"}}></div>
-      </div>
-    </div>
-  );
+  return <div id="sidebar">{children}</div>;
 }
 
 // from date.strftime('%Y/%m/%d %H:%M')
@@ -97,17 +55,16 @@ export async function TagCloud() {
 function formatDate(date: Date) {
   return (
     date.getFullYear() +
-      "/" +
-      String(date.getMonth() + 1).padStart(2, "0") +
-      "/" +
-      String(date.getDate()).padStart(2, "0") +
-      " " +
-      String(date.getHours()).padStart(2, "0") +
-      ":" +
-      String(date.getMinutes()).padStart(2, "0")
+    "/" +
+    String(date.getMonth() + 1).padStart(2, "0") +
+    "/" +
+    String(date.getDate()).padStart(2, "0") +
+    " " +
+    String(date.getHours()).padStart(2, "0") +
+    ":" +
+    String(date.getMinutes()).padStart(2, "0")
   );
 }
-
 
 export async function Panorama() {
   // TODO: fetch panoramaList from database
@@ -115,7 +72,10 @@ export async function Panorama() {
     {
       action: { value: "new-article" },
       article: {
-        no: 1, title: "Test Article", bbs_name: "자유게시판", bbs_url: "2",
+        no: 1,
+        title: "Test Article",
+        bbs_name: "자유게시판",
+        bbs_url: "2",
         user: { no: 1, name: "Admin" },
       },
       actor: { no: 1, name: "Admin", email: "admin@example.com" },
@@ -124,14 +84,18 @@ export async function Panorama() {
     {
       action: { value: "new-comment" },
       article: {
-        no: 1, title: "Test Article", bbs_name: "자유게시판", bbs_url: "2",
+        no: 1,
+        title: "Test Article",
+        bbs_name: "자유게시판",
+        bbs_url: "2",
         user: { no: 1, name: "Admin" },
       },
       actor: { no: 1, name: "Admin", email: "admin@example.com" },
       date: new Date(),
     },
   ];
-  const makeGravatarUrl = (_email: string, _size: number) => "https://example.com";
+  const makeGravatarUrl = (_email: string, _size: number) =>
+    "https://example.com";
   const prettyDate = (date: Date) => formatDate(date);
   return (
     <>
@@ -143,41 +107,51 @@ export async function Panorama() {
         <div id="panorama_content" className="content_horizontal">
           <div id="panorama_nano" className="nano">
             <div id="panorama_nano_content" className="nano-content">
-              {panoramaList.map((panorama, index) => (
-                panorama.article === null ?
+              {panoramaList.map((panorama, index) =>
+                panorama.article === null ? (
                   <div className="panorama_row article" key={index}>
                     <span>삭제된 게시글입니다.</span>
                   </div>
-                  :
+                ) : (
                   <div className="panorama_row article" key={index}>
-                    <img src={makeGravatarUrl(panorama.actor.email, 32)} height="32px" />
+                    <img
+                      src={makeGravatarUrl(panorama.actor.email, 32)}
+                      height="32px"
+                    />
                     <div className="panorama-row-content">
                       <Link href={`/${panorama.article.no}`}>
-                        {panorama.action.value === "new-article" ?
-                          `${panorama.actor.name} 님의 글 [${panorama.article.title}]이(가) 등록되었습니다.` :
-                          panorama.action.value === "new-comment" ?
-                          `${panorama.actor.name} 님이 글 [${panorama.article.title}]에 댓글을 다셨습니다.` :
-                          null
-                        }
+                        {panorama.action.value === "new-article"
+                          ? `${panorama.actor.name} 님의 글 [${panorama.article.title}]이(가) 등록되었습니다.`
+                          : panorama.action.value === "new-comment"
+                            ? `${panorama.actor.name} 님이 글 [${panorama.article.title}]에 댓글을 다셨습니다.`
+                            : null}
                       </Link>
                       /
-                      {panorama.article.bbs_name === "지름게시판" ?
-                        (<>
+                      {panorama.article.bbs_name === "지름게시판" ? (
+                        <>
                           <Link href="/purchases" className="panorama_board">
                             {panorama.article.bbs_name}
                           </Link>
                           <br />
-                        </>) :
-                          (<Link href={`/board/${panorama.article.bbs_url}`} className="panorama_board">
-                            {panorama.article.bbs_name}
-                          </Link>)
-                      }
-                      <span title={formatDate(panorama.date)} className="datatime">
+                        </>
+                      ) : (
+                        <Link
+                          href={`/board/${panorama.article.bbs_url}`}
+                          className="panorama_board"
+                        >
+                          {panorama.article.bbs_name}
+                        </Link>
+                      )}
+                      <span
+                        title={formatDate(panorama.date)}
+                        className="datatime"
+                      >
                         ({prettyDate(panorama.date)})
                       </span>
                     </div>
                   </div>
-              ))}
+                ),
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
로그인사용자가 보게되는 메인페이지의 껍데기를 구현하였습니다. 작동하는 부분은 두가지입니다.
- 메뉴에 호버하면 게시판 목록이 뜸
- 로그아웃하면 세션을 지우고 `/`로 리다이렉트

기존 홈페이지에서 jinja block으로 구현한 부분은 조립식 컴포넌트를 사용하면 됩니다. block을 사용하는 경우는 대개 1) 사이드바 제거, 2) 파노라마 제거, 3) 사이드바 요소 추가 중 하나이므로 이러한 마이그레이션이 어렵지 않을 겁니다.
```jsx
import { Container, SideBar, TagCloud, Main, Panorama } from "@/components/internalTemplates";
  // in page.tsx, return like this:
  return (
    <Container>
      <SideBar>
        ...add_sidebar
        <TagCloud/>
      </SideBar>
      <Main>
        ...contents
      </Main>
      <Panorama/>
    </Container>
  );

  // or, without sidebar:
  return (
    <Container>
      <MainAlone>
        ...contents
      </MainAlone>
      <Panorama/>
    </Container>
  );

```
자세한 내용은 components/internalTemplates.tsx와 app/(unlogin)/main/page.tsx를 참고하세요.