### PR TITLE
Study main page

### DIFF
--- a/app/(login)/studies/page.tsx
+++ b/app/(login)/studies/page.tsx
@@ -1,9 +1,9 @@
-import { Container, SideBar, Main } from '@/components/internalTemplates';
-import StudySidebar from '@/components/study/StudySidebar';
-import StudyGrid from '@/components/study/StudyGrid';
-import TagCloud from '@/components/study/TagCloud';
-import { getStudiesDataSuite } from '@/utils/database/study';
-import { getTagData } from '@/utils/database/project';
+import { Container, SideBar, Main } from "@/components/internalTemplates";
+import StudySidebar from "@/components/study/StudySidebar";
+import StudyGrid from "@/components/study/StudyGrid";
+import TagCloud from "@/components/study/TagCloud";
+import { getStudiesDataSuite } from "@/utils/database/study";
+import { getTagData } from "@/utils/database/tag";
 
 export default async function StudyPage() {
   const { workingStudies, pendingStudies } = await getStudiesDataSuite();
@@ -12,7 +12,10 @@ export default async function StudyPage() {
   return (
     <Container>
       <SideBar>
-        <StudySidebar workingStudies={workingStudies} pendingStudies={pendingStudies} />
+        <StudySidebar
+          workingStudies={workingStudies}
+          pendingStudies={pendingStudies}
+        />
         <TagCloud tags={tagList} />
       </SideBar>
       <Main>

--- a/app/(login)/studies/page.tsx
+++ b/app/(login)/studies/page.tsx
@@ -1,9 +1,14 @@
+// @/app/(login)/studies/page.tsx
+
+// Component
 import { Container, SideBar, Main } from "@/components/internalTemplates";
 import StudySidebar from "@/components/study/StudySidebar";
 import StudyGrid from "@/components/study/StudyGrid";
 import TagCloud from "@/components/study/TagCloud";
+// Database
 import { getStudiesDataSuite } from "@/utils/database/study";
 import { getTagData } from "@/utils/database/tag";
+// Style
 import '@/app/(login)/studies/study.css'
 
 export default async function StudyPage() {

--- a/app/(login)/studies/page.tsx
+++ b/app/(login)/studies/page.tsx
@@ -4,6 +4,7 @@ import StudyGrid from "@/components/study/StudyGrid";
 import TagCloud from "@/components/study/TagCloud";
 import { getStudiesDataSuite } from "@/utils/database/study";
 import { getTagData } from "@/utils/database/tag";
+import '@/app/(login)/studies/study.css'
 
 export default async function StudyPage() {
   const { workingStudies, pendingStudies } = await getStudiesDataSuite();

--- a/app/(login)/studies/page.tsx
+++ b/app/(login)/studies/page.tsx
@@ -1,0 +1,23 @@
+import { Container, SideBar, Main } from '@/components/internalTemplates';
+import StudySidebar from '@/components/study/StudySidebar';
+import StudyGrid from '@/components/study/StudyGrid';
+import TagCloud from '@/components/study/TagCloud';
+import { getStudiesDataSuite } from '@/utils/database/study';
+import { getTagData } from '@/utils/database/project';
+
+export default async function StudyPage() {
+  const { workingStudies, pendingStudies } = await getStudiesDataSuite();
+  const { tagList } = await getTagData();
+
+  return (
+    <Container>
+      <SideBar>
+        <StudySidebar workingStudies={workingStudies} pendingStudies={pendingStudies} />
+        <TagCloud tags={tagList} />
+      </SideBar>
+      <Main>
+        <StudyGrid studies={[...workingStudies, ...pendingStudies]} />
+      </Main>
+    </Container>
+  );
+}

--- a/app/(login)/studies/study.css
+++ b/app/(login)/studies/study.css
@@ -1,0 +1,150 @@
+#board_list_content h4 {
+  float: left;
+  margin: 0;
+  line-height: 30px;
+  font-size: 14px;
+}
+
+.list_switch {
+  float: right;
+  margin-right: 10px;
+  line-height: 30px;
+  cursor: pointer;
+}
+
+#working_study_list, #pending_study_list {
+  clear: both;
+}
+
+#study {
+  width: 730px;
+}
+
+#study_title {
+  float: left;
+  display: inline-block;
+}
+
+#study_title h3 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+#new_study {
+  float: right;
+  width: 100px;
+  height: 30px;
+  margin-top: 0px;
+  margin-right: 15px;
+  padding: 1px 6px;
+}
+
+#study_detail {
+  clear: both;
+  display: flex;
+  flex-wrap: wrap;
+  padding: 5px 0;
+}
+
+.study {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width:350px;
+  min-height:160px;
+  margin: 5px;
+  margin-right: 10px;
+  box-sizing: border-box;
+  padding: 10px;
+}
+.study:nth-child(2n) {
+  margin-right: 0px;
+}
+
+.study_info {
+  flex: 1;
+}
+
+.study_title {
+  display: inline-block;
+  margin: 0;
+  margin-bottom: 10px;
+  margin-right: 5px;
+  font-size: 15px;
+  line-height: 20px;
+  font-weight:bold;
+}
+
+.study_date {
+  display: inline-block;
+  line-height: 20px;
+}
+
+.study_about {
+  font-size:15px;
+  min-height:60px;
+  width:100%;
+  margin-bottom:10px;
+}
+
+.study_member {
+  text-align: left;
+  font-size:12px;
+}
+
+.study_member_all {
+  text-align: left;
+  font-size: 12px;
+}
+
+.study_tag button {
+  padding: 1px 2px;
+  font-size: 12px;
+}
+
+.tags {
+  margin: 5px 0px;
+  font-size:10px;
+}
+
+.tags span {
+  font-weight: bold;
+}
+
+.tags button {
+  padding: 1px 2px;
+  font-size: 12px;
+}
+
+form, .control-group, .control-group label, .controls, .control-group input {
+  display: inline;
+  margin: 0;
+}
+
+.control-label {
+}
+
+.controls input {
+  width: 65px;
+  height: 20px;
+  margin: 10px 0px;
+}
+
+.study_manage {
+  text-align: right;
+  font-size: 12px;
+}
+
+#pages {
+  clear: both;
+  display: inline-block;
+  margin-top: 10px;
+  margin-left: 180px;
+}
+
+.page_number {
+  float: left;
+  width: 30px;
+  text-align: center;
+}

--- a/components/study/StudyCard.tsx
+++ b/components/study/StudyCard.tsx
@@ -1,9 +1,9 @@
 // @/components/study/StudyCard
 
 // Next
-import Link from 'next/link';
+import Link from "next/link";
 // Type
-import { StudySuite } from '@/utils/typeSuite';
+import { StudySuite } from "@/utils/typeSuite";
 
 export default function StudyCard({ study }: { study: StudySuite }) {
   return (
@@ -13,8 +13,15 @@ export default function StudyCard({ study }: { study: StudySuite }) {
           <Link href={`/board/${study.board_no}`}>{study.name}</Link>
         </h4>
         <div className="study_date">
-          <span className="date">{study.start_date.slice(0, 7).replace('-', '.')}</span> ~{' '}
-          <span className="date">{study.finish_date ? study.finish_date.slice(0, 7).replace('-', '.') : ''}</span>
+          <span className="date">
+            {study.start_date.slice(0, 7).replace("-", ".")}
+          </span>{" "}
+          ~{" "}
+          <span className="date">
+            {study.finish_date
+              ? study.finish_date.slice(0, 7).replace("-", ".")
+              : ""}
+          </span>
         </div>
         <div className="study_about">
           <span>{study.introduction}</span>
@@ -29,7 +36,9 @@ export default function StudyCard({ study }: { study: StudySuite }) {
       <div className="study_tag">
         <span>TAG </span>
         {study.tag_list.map((tag, idx) => (
-          <span key={idx} className="tags_link">{tag}</span>
+          <span key={idx} className="tags_link">
+            {tag}
+          </span>
         ))}
       </div>
     </div>

--- a/components/study/StudyCard.tsx
+++ b/components/study/StudyCard.tsx
@@ -7,7 +7,7 @@ import { StudySuite } from "@/utils/typeSuite";
 
 export default function StudyCard({ study }: { study: StudySuite }) {
   return (
-    <div className="study-card">
+    <div className="study-card study article">
       <div className="study_info">
         <h4 className="study_title">
           <Link href={`/board/${study.board_no}`}>{study.name}</Link>

--- a/components/study/StudyCard.tsx
+++ b/components/study/StudyCard.tsx
@@ -1,4 +1,4 @@
-// @/components/study/StudyCard
+// @/components/study/StudyCard.tsx
 
 // Next
 import Link from "next/link";

--- a/components/study/StudyCard.tsx
+++ b/components/study/StudyCard.tsx
@@ -1,0 +1,37 @@
+// @/components/study/StudyCard
+
+// Next
+import Link from 'next/link';
+// Type
+import { StudySuite } from '@/utils/typeSuite';
+
+export default function StudyCard({ study }: { study: StudySuite }) {
+  return (
+    <div className="study-card">
+      <div className="study_info">
+        <h4 className="study_title">
+          <Link href={`/board/${study.board_no}`}>{study.name}</Link>
+        </h4>
+        <div className="study_date">
+          <span className="date">{study.start_date.slice(0, 7).replace('-', '.')}</span> ~{' '}
+          <span className="date">{study.finish_date ? study.finish_date.slice(0, 7).replace('-', '.') : ''}</span>
+        </div>
+        <div className="study_about">
+          <span>{study.introduction}</span>
+        </div>
+      </div>
+      <div className="study_member_all">
+        <span>멤버 : </span>
+        {study.participant_list.map((u, idx) => (
+          <span key={idx}>{u.name}</span>
+        ))}
+      </div>
+      <div className="study_tag">
+        <span>TAG </span>
+        {study.tag_list.map((tag, idx) => (
+          <span key={idx} className="tags_link">{tag}</span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/study/StudyGrid.tsx
+++ b/components/study/StudyGrid.tsx
@@ -1,9 +1,9 @@
 // @/components/study/StudyGrid
 
 // Component
-import StudyCard from '@/components/study/StudyCard';
+import StudyCard from "@/components/study/StudyCard";
 // Type
-import { StudySuite } from '@/utils/typeSuite';
+import { StudySuite } from "@/utils/typeSuite";
 
 export default function StudyGrid({
   studies,

--- a/components/study/StudyGrid.tsx
+++ b/components/study/StudyGrid.tsx
@@ -1,0 +1,25 @@
+// @/components/study/StudyGrid
+
+// Component
+import StudyCard from '@/components/study/StudyCard';
+// Type
+import { StudySuite } from '@/utils/typeSuite';
+
+export default function StudyGrid({
+  studies,
+  cardWidth = 355,
+}: {
+  studies: StudySuite[];
+  cardWidth?: number;
+}) {
+  return (
+    <div
+      className="contentbox__grid-content"
+      style={{ gridTemplateColumns: `repeat(auto-fit, ${cardWidth}px)` }}
+    >
+      {studies.map((study) => (
+        <StudyCard key={study.no} study={study} />
+      ))}
+    </div>
+  );
+}

--- a/components/study/StudyGrid.tsx
+++ b/components/study/StudyGrid.tsx
@@ -1,4 +1,4 @@
-// @/components/study/StudyGrid
+// @/components/study/StudyGrid.tsx
 
 // Component
 import StudyCard from "@/components/study/StudyCard";

--- a/components/study/StudyGrid.tsx
+++ b/components/study/StudyGrid.tsx
@@ -2,24 +2,25 @@
 
 // Component
 import StudyCard from "@/components/study/StudyCard";
+// Common Layout
+import { ContentBox, ContentBoxTitle, ContentBoxGridContent } from "@/components/commons";
 // Type
 import { StudySuite } from "@/utils/typeSuite";
 
-export default function StudyGrid({
-  studies,
-  cardWidth = 355,
-}: {
-  studies: StudySuite[];
-  cardWidth?: number;
-}) {
+export default function StudyGrid({ studies, cardWidth = 355 } : { studies: StudySuite[]; cardWidth?: number; }) {
   return (
-    <div
-      className="contentbox__grid-content"
-      style={{ gridTemplateColumns: `repeat(auto-fit, ${cardWidth}px)` }}
-    >
-      {studies.map((study) => (
-        <StudyCard key={study.no} study={study} />
-      ))}
-    </div>
+    <ContentBox id="study_grid" styles={{}} >
+      <ContentBoxTitle
+        content="스터디"
+        button={{ href: "/create/study", text: "새 스터디" }}
+      />
+      <div id="study_detail" className="subbackboard">
+        <ContentBoxGridContent cardWidth={cardWidth} id="study_grid_content" styles={{}} >
+          {studies.map((study) => (
+            <StudyCard key={study.no} study={study} />
+          ))}
+        </ContentBoxGridContent>
+      </div>
+    </ContentBox>
   );
 }

--- a/components/study/StudySidebar.tsx
+++ b/components/study/StudySidebar.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { StudySuite } from '@/utils/typeSuite';
+import { SideBox, SideBoxTitle, SideBoxContent } from '@/components/commons';
+import Link from 'next/link';
+
+type StudySidebarProps = {
+  workingStudies: StudySuite[];
+  pendingStudies: StudySuite[];
+};
+
+export default function StudySidebar({ workingStudies, pendingStudies }: StudySidebarProps) {
+  return (
+    <SideBox id="board_list">
+      <SideBoxTitle content="스터디" />
+      <SideBoxContent id="board_list_content">
+        <h4>진행중인 스터디</h4>
+        <ul>
+          {workingStudies.map(study => (
+            <li key={study.no}>
+              └ <Link href={`/board/${study.board_no}`}>{study.name}</Link>
+            </li>
+          ))}
+        </ul>
+        <h4>완료된 스터디</h4>
+        <ul>
+          {pendingStudies.map(study => (
+            <li key={study.no}>
+              └ <Link href={`/board/${study.board_no}`}>{study.name}</Link>
+            </li>
+          ))}
+        </ul>
+      </SideBoxContent>
+    </SideBox>
+  );
+}

--- a/components/study/StudySidebar.tsx
+++ b/components/study/StudySidebar.tsx
@@ -1,8 +1,17 @@
+// @/components/StudySidebar.tsx
+
 "use client";
 
-import { StudySuite } from "@/utils/typeSuite";
+// Component
 import { SideBox, SideBoxTitle, SideBoxContent } from "@/components/commons";
+// Next
 import Link from "next/link";
+// React
+import { useState } from "react";
+// Style
+import "@/styles/login/study/study-sidebar.css";
+// Type
+import { StudySuite } from "@/utils/typeSuite";
 
 type StudySidebarProps = {
   workingStudies: StudySuite[];
@@ -13,26 +22,40 @@ export default function StudySidebar({
   workingStudies,
   pendingStudies,
 }: StudySidebarProps) {
+  const [showWorking, setShowWorking] = useState(false);
+  const [showPending, setShowPending] = useState(false);
+
   return (
     <SideBox id="board_list">
       <SideBoxTitle content="스터디" />
       <SideBoxContent id="board_list_content">
-        <h4>진행중인 스터디</h4>
-        <ul>
-          {workingStudies.map((study) => (
-            <li key={study.no}>
-              └ <Link href={`/board/${study.board_no}`}>{study.name}</Link>
-            </li>
-          ))}
-        </ul>
-        <h4>완료된 스터디</h4>
-        <ul>
-          {pendingStudies.map((study) => (
-            <li key={study.no}>
-              └ <Link href={`/board/${study.board_no}`}>{study.name}</Link>
-            </li>
-          ))}
-        </ul>
+        <div className="study_toggle_section" onClick={() => setShowWorking((prev) => !prev)}>
+          <h4 className="study_toggle_title"> 진행중인 스터디 </h4>
+          <span className="list_switch"> {showWorking ? "−" : "+"}</span>
+        </div>
+        {showWorking && (
+          <ul id="working_study_list" className="study_list">
+            {workingStudies.map((study) => (
+              <li key={study.no}>
+                └ <Link href={`/board/${study.board_no}`}>{study.name}</Link>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="study_toggle_section" onClick={() => setShowPending((prev) => !prev)}>
+          <h4 className="study_toggle_title">완료된 스터디</h4>
+          <span className="list_switch" >{showPending ? "−" : "+"}</span>
+        </div>
+        {showPending && (
+          <ul id="pending_study_list" className="study_list">
+            {pendingStudies.map((study) => (
+              <li key={study.no}>
+                └ <Link href={`/board/${study.board_no}`}>{study.name}</Link>
+              </li>
+            ))}
+          </ul>
+        )}
       </SideBoxContent>
     </SideBox>
   );

--- a/components/study/StudySidebar.tsx
+++ b/components/study/StudySidebar.tsx
@@ -1,4 +1,4 @@
-// @/components/StudySidebar.tsx
+// @/components/study/StudySidebar.tsx
 
 "use client";
 

--- a/components/study/StudySidebar.tsx
+++ b/components/study/StudySidebar.tsx
@@ -1,22 +1,25 @@
-'use client';
+"use client";
 
-import { StudySuite } from '@/utils/typeSuite';
-import { SideBox, SideBoxTitle, SideBoxContent } from '@/components/commons';
-import Link from 'next/link';
+import { StudySuite } from "@/utils/typeSuite";
+import { SideBox, SideBoxTitle, SideBoxContent } from "@/components/commons";
+import Link from "next/link";
 
 type StudySidebarProps = {
   workingStudies: StudySuite[];
   pendingStudies: StudySuite[];
 };
 
-export default function StudySidebar({ workingStudies, pendingStudies }: StudySidebarProps) {
+export default function StudySidebar({
+  workingStudies,
+  pendingStudies,
+}: StudySidebarProps) {
   return (
     <SideBox id="board_list">
       <SideBoxTitle content="스터디" />
       <SideBoxContent id="board_list_content">
         <h4>진행중인 스터디</h4>
         <ul>
-          {workingStudies.map(study => (
+          {workingStudies.map((study) => (
             <li key={study.no}>
               └ <Link href={`/board/${study.board_no}`}>{study.name}</Link>
             </li>
@@ -24,7 +27,7 @@ export default function StudySidebar({ workingStudies, pendingStudies }: StudySi
         </ul>
         <h4>완료된 스터디</h4>
         <ul>
-          {pendingStudies.map(study => (
+          {pendingStudies.map((study) => (
             <li key={study.no}>
               └ <Link href={`/board/${study.board_no}`}>{study.name}</Link>
             </li>

--- a/components/study/TagCloud.tsx
+++ b/components/study/TagCloud.tsx
@@ -1,20 +1,20 @@
 // components/TagCloud.tsx
 
 // Components
-import { SideBox, SideBoxTitle, SideBoxContent } from '@/components/commons'
+import { SideBox, SideBoxTitle, SideBoxContent } from "@/components/commons";
 // Styles
-import '@/styles/login/projects/tagcloud.css'
+import "@/styles/login/study/tagcloud.css";
 // Types
-import { TagCount } from '@/utils/types'
+import { TagCount } from "@/utils/types";
 
 function tagLevel(count: number): string {
-  if (count > 10) return 'tag-contents__tag--xl'
-  if (count > 5) return 'tag-contents__tag--lg'
-  if (count > 2) return 'tag-contents__tag--md'
-  return 'tag-contents__tag--sm'
+  if (count > 10) return "tag-contents__tag--xl";
+  if (count > 5) return "tag-contents__tag--lg";
+  if (count > 2) return "tag-contents__tag--md";
+  return "tag-contents__tag--sm";
 }
 
-type TagCloudProps = { tags: TagCount[] }
+type TagCloudProps = { tags: TagCount[] };
 export default function TagCloud({ tags }: TagCloudProps) {
   return (
     <SideBox>
@@ -24,10 +24,15 @@ export default function TagCloud({ tags }: TagCloudProps) {
           <div className="tag-contents__list">
             {tags.map((tag, idx) => (
               <span key={tag.no} className="tag-contents__item">
-                <a className={`tag-contents__tag ${tagLevel(tag.count)}`} href={`/tag/${tag.no}`}>
+                <a
+                  className={`tag-contents__tag ${tagLevel(tag.count)}`}
+                  href={`/tag/${tag.no}`}
+                >
                   {tag.content}
                 </a>
-                {idx !== tags.length - 1 && <span className="tag-contents__bar">|</span>}
+                {idx !== tags.length - 1 && (
+                  <span className="tag-contents__bar">|</span>
+                )}
               </span>
             ))}
           </div>
@@ -38,5 +43,5 @@ export default function TagCloud({ tags }: TagCloudProps) {
         </div>
       </SideBoxContent>
     </SideBox>
-  )
+  );
 }

--- a/components/study/TagCloud.tsx
+++ b/components/study/TagCloud.tsx
@@ -1,4 +1,4 @@
-// components/TagCloud.tsx
+// @/components/study/TagCloud.tsx
 
 // Components
 import { SideBox, SideBoxTitle, SideBoxContent } from "@/components/commons";

--- a/components/study/TagCloud.tsx
+++ b/components/study/TagCloud.tsx
@@ -1,0 +1,42 @@
+// components/TagCloud.tsx
+
+// Components
+import { SideBox, SideBoxTitle, SideBoxContent } from '@/components/commons'
+// Styles
+import '@/styles/login/projects/tagcloud.css'
+// Types
+import { TagCount } from '@/utils/types'
+
+function tagLevel(count: number): string {
+  if (count > 10) return 'tag-contents__tag--xl'
+  if (count > 5) return 'tag-contents__tag--lg'
+  if (count > 2) return 'tag-contents__tag--md'
+  return 'tag-contents__tag--sm'
+}
+
+type TagCloudProps = { tags: TagCount[] }
+export default function TagCloud({ tags }: TagCloudProps) {
+  return (
+    <SideBox>
+      <SideBoxTitle content="태그" />
+      <SideBoxContent>
+        <div className="tag-contents">
+          <div className="tag-contents__list">
+            {tags.map((tag, idx) => (
+              <span key={tag.no} className="tag-contents__item">
+                <a className={`tag-contents__tag ${tagLevel(tag.count)}`} href={`/tag/${tag.no}`}>
+                  {tag.content}
+                </a>
+                {idx !== tags.length - 1 && <span className="tag-contents__bar">|</span>}
+              </span>
+            ))}
+          </div>
+          <div className="tag-contents__search">
+            <input className="tag-contents__input" type="text" />
+            <button className="tag-contents__button">검색</button>
+          </div>
+        </div>
+      </SideBoxContent>
+    </SideBox>
+  )
+}

--- a/styles/login/study/study-sidebar.css
+++ b/styles/login/study/study-sidebar.css
@@ -1,0 +1,26 @@
+/* @/styles/login/study/study-sidebar.css */
+
+.study_toggle_section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+}
+
+.study_toggle_title {
+  font-size: 14px;
+  font-weight: 600;
+  user-select: none;
+}
+
+.list_switch {
+  font-size: 14px;
+  user-select: none;
+}
+
+.study_list {
+  margin-left: 1rem;
+  margin-top: 0.5rem;
+  list-style: none;
+  padding-left: 0;
+}

--- a/styles/login/study/tagcloud.css
+++ b/styles/login/study/tagcloud.css
@@ -1,0 +1,69 @@
+/* @/styles/login/projects/tagcloud.css */
+
+/* Container for the entire tag block */
+.tag-contents {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+} 
+.tag-contents__list { min-height: 230px; }
+
+/* Tag */
+.tag-contents__item {
+  display: inline-block;
+  margin-right: 4px;
+}
+.tag-contents__tag {
+  color: #181818;
+  text-decoration: none;
+  &:hover { color: #ffffff; background-color: #6d6d6d; }
+}
+
+/* Tag size modifiers based on frequency */
+.tag-contents__tag--sm { font-size: 1em; }
+.tag-contents__tag--md { font-size: 1.2em; }
+.tag-contents__tag--lg { font-size: 1.4em; font-weight: bold; }
+.tag-contents__tag--xl { font-size: 1.6em; font-weight: bolder; }
+/* Separator between tags */
+.tag-contents__bar { margin: 1px; }
+
+/* Container for the search */
+.tag-contents__search {
+  width: 100%;
+  margin: 5px 0;
+  display: flex;
+  gap: 3px;
+}
+
+/* Search input field */
+.tag-contents__input {
+  height: 30px;
+  min-width: 60px;
+  flex: 3;
+
+  padding: 5px;
+  margin: 0;
+
+  background: #bcbcbc;
+  border: 1px solid #888;
+  box-shadow: inset 0 0 10px rgba(255, 255, 190, 0.43);
+  border-radius: 0;
+}
+
+/* Search button */
+.tag-contents__button {
+  height: 30px;
+  width: 80px;
+  flex: 1;
+
+  background: #454545;
+  box-shadow: none;
+  color: #ffffff;
+  border: 1px solid black;
+
+  font-weight: bold;
+  cursor: pointer;
+
+  &:hover { background-color: #5a5a5a; }
+}

--- a/styles/login/study/tagcloud.css
+++ b/styles/login/study/tagcloud.css
@@ -1,4 +1,4 @@
-/* @/styles/login/projects/tagcloud.css */
+/* @/styles/login/styles/tagcloud.css */
 
 /* Container for the entire tag block */
 .tag-contents {

--- a/utils/database/study.ts
+++ b/utils/database/study.ts
@@ -1,0 +1,79 @@
+// utils/database/study.ts
+
+// Type
+import { StudySuite } from "../typeSuite";
+
+export function getStudiesDataSuite(): {
+  workingStudies: StudySuite[];
+  pendingStudies: StudySuite[];
+} {
+  const allStudies: StudySuite[] = [
+    {
+      no: 35,
+      name: "TRPG 스터디?",
+      introduction:
+        "여러 참여자가 정해진 시간에 모여 의견을 나누면 스터디가 아닐까?",
+      status: "working",
+      board_no: 197,
+      start_date: "2023-08-10",
+      finish_date: null,
+      orderer_id: 33,
+      participant_list: [{ name: "홍길동" }, { name: "김철수" }],
+      tag_list: ["TRPG", "참여형"],
+    },
+    {
+      no: 43,
+      name: "어려운책스터디",
+      introduction: "어려운 책 같이 읽읍시다",
+      status: "working",
+      board_no: 224,
+      start_date: "2024-09-23",
+      finish_date: null,
+      orderer_id: 258,
+      participant_list: [{ name: "이영희" }],
+      tag_list: ["독서", "심화"],
+    },
+    {
+      no: 45,
+      name: "동기 부여 스터디",
+      introduction: "으쌰으쌰",
+      status: "working",
+      board_no: 228,
+      start_date: "2025-01-06",
+      finish_date: null,
+      orderer_id: 33,
+      participant_list: [{ name: "박지성" }],
+      tag_list: ["자기계발"],
+    },
+    {
+      no: 29,
+      name: "FastAPI 스터디",
+      introduction:
+        "Python 기반의 강력한 백엔드 서버 개발 프레임워크인 FastAPI를 공부합니다.",
+      status: "pending",
+      board_no: 161,
+      start_date: "2022-12-30",
+      finish_date: "2023-04-01",
+      orderer_id: 56,
+      participant_list: [{ name: "강명석" }, { name: "김개발" }],
+      tag_list: ["Python", "백엔드"],
+    },
+    {
+      no: 40,
+      name: "2024 Rust Study",
+      introduction: "Rust를 배워보자!",
+      status: "pending",
+      board_no: 216,
+      start_date: "2024-04-05",
+      finish_date: "2024-09-09",
+      orderer_id: 274,
+      participant_list: [{ name: "서준호" }],
+      tag_list: ["Rust"],
+    },
+  ];
+
+  return {
+    workingStudies: allStudies.filter((s) => s.status === "working"),
+    pendingStudies: allStudies.filter((s) => s.status === "pending"),
+  };
+}

--- a/utils/database/tag.ts
+++ b/utils/database/tag.ts
@@ -1,0 +1,16 @@
+// @/utils/database/tag.ts
+
+// Type
+import { TagCount } from "@/utils/types";
+
+export async function getTagData(): Promise<{
+  tagList: TagCount[];
+}> {
+  const tagList: TagCount[] = [
+    { no: 1, content: "DB", count: 3 },
+    { no: 2, content: "게임", count: 2 },
+    { no: 3, content: "퍼즐", count: 1 },
+  ];
+
+  return { tagList };
+}

--- a/utils/typeSuite.ts
+++ b/utils/typeSuite.ts
@@ -25,7 +25,7 @@ export type StudySuite = {
   introduction: string;
   status: "working" | "pending";
   board_no: number;
-  start_date: string; // ISO date string (e.g., '2025-01-01')
+  start_date: string; // ISO date string ('2025-01-01')
   finish_date: string | null;
   orderer_id: number;
   participant_list: { name: string }[];

--- a/utils/typeSuite.ts
+++ b/utils/typeSuite.ts
@@ -1,33 +1,33 @@
 // /types/project.ts
 
 export type ProjectSuite = {
-  no: number
-  name: string
-  genre: string
-  is_public: boolean
-  introduction: string
-  detail: string
-  start_date: string
-  finish_date: string | null
-  thumbnail?: string
-  status: string
-  bbs_url: number
-  orderer_id: number
-  executable: string
-  is_show_page: boolean
-  participant_list: { name: string }[]
-  tag_list: string[]
-}
+  no: number;
+  name: string;
+  genre: string;
+  is_public: boolean;
+  introduction: string;
+  detail: string;
+  start_date: string;
+  finish_date: string | null;
+  thumbnail?: string;
+  status: string;
+  bbs_url: number;
+  orderer_id: number;
+  executable: string;
+  is_show_page: boolean;
+  participant_list: { name: string }[];
+  tag_list: string[];
+};
 
 export type StudySuite = {
   no: number;
   name: string;
   introduction: string;
-  status: 'working' | 'pending';
+  status: "working" | "pending";
   board_no: number;
-  start_date: string;         // ISO date string (e.g., '2025-01-01')
+  start_date: string; // ISO date string (e.g., '2025-01-01')
   finish_date: string | null;
   orderer_id: number;
-  participant_list: { name: string }[]
-  tag_list: string[]
+  participant_list: { name: string }[];
+  tag_list: string[];
 };

--- a/utils/typeSuite.ts
+++ b/utils/typeSuite.ts
@@ -1,0 +1,33 @@
+// /types/project.ts
+
+export type ProjectSuite = {
+  no: number
+  name: string
+  genre: string
+  is_public: boolean
+  introduction: string
+  detail: string
+  start_date: string
+  finish_date: string | null
+  thumbnail?: string
+  status: string
+  bbs_url: number
+  orderer_id: number
+  executable: string
+  is_show_page: boolean
+  participant_list: { name: string }[]
+  tag_list: string[]
+}
+
+export type StudySuite = {
+  no: number;
+  name: string;
+  introduction: string;
+  status: 'working' | 'pending';
+  board_no: number;
+  start_date: string;         // ISO date string (e.g., '2025-01-01')
+  finish_date: string | null;
+  orderer_id: number;
+  participant_list: { name: string }[]
+  tag_list: string[]
+};


### PR DESCRIPTION
# 로그인한 사용자의 Study 메인 페이지 작성

> 작성자 Serius <tomskang@naver.com>  
> 작성일 2025-05-27

로그인한 사용자의 스터디 메인 페이지를 제작하였음.

---

## page.js 구조

주요 구조

```tsx
<Container>
  <SideBar>
    <StudySidebar
      workingStudies={workingStudies}
      pendingStudies={pendingStudies}
    />
    <TagCloud tags={tagList} />
  </SideBar>
  <Main>
    <StudyGrid studies={[...workingStudies, ...pendingStudies]} />
  </Main>
</Container>
```

---

## TagCloud

- `project`의 내용과 정확히 같은 것이 `study`에도 존재해야 함
- 일단 PR을 project PR과 독립적으로 만들기 위해 임시방편으로 `@/components/study/TagCloud.tsx`를 제작
- 이후 별도의 PR로 병합할 예정

---

## components/study

- `study` 페이지의 경우 비로그인 사용자 페이지는 없음  
- 따라서 `/pages.tsx`와 같은 위치에 두어도 됨

별도로 분리한 이유는 다음과 같음:

1. `page.tsx`와 독립되므로 보기 편안함  
   → 한 폴더 안에 `page.tsx`, `StudyCard`, `StudyGrid`, `StudySidebar` 다 있으면 보기 불편하다는 사실을 도출했으며, 이에 따라 옮김

2. `projects` 폴더와 비슷한 dependency, 유사한 구조를 가짐  
   → 함께 있는 것이 타당하다고 판단함

3. (추후 계획) 이렇게 개발하면 `styles/` 폴더와 대응 관계를 만들기 더 편함

