### PR TITLE
Database migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ next-env.d.ts
 
 # generated Prisma client
 /prisma/client
+/prisma-psql/client

--- a/README.md
+++ b/README.md
@@ -32,3 +32,17 @@ docker-compose down
 ```
 
 - `schema.prisma`의 column 이름을 바꿀 경우 Prisma는 column을 `DROP`하고 새로 만드는 방식으로 migrate한다. 이렇게 하면 해당 column 정보가 전부 날아가 버리므로, `--create-only`으로 먼저 `migration.sql`을 만든 다음 쿼리를 직접 `ALTER RENAME`으로 수정해야 한다.
+
+## PostgreSQL -> local MySQL DB migration
+
+- 우선 로컬에 PostgreSQL 컨테이너를 하나 띄우고 덤프된 데이터를 집어넣음
+  - docker-compose.yml의 `upnl-postgres` 컨테이너를 uncomment하고 실행
+  - Postgresql에서 dump된 파일을 `docker/postgres` 폴더 안에 `init.sql`이라는 이름으로 복사하기
+  - `upnl-postgres` 컨테이너 안에 들어가기 (`docker exec -it upnl-postgres /bin/sh`)
+  - `psql --username=upnl postgres < /var/lib/postgresql/data/init.sql` 실행
+    - `psql -U upnl postgres`로 DB에 접속해서 `\dt` 를 입력했을 때 테이블들이 쿼리되면 데이터들이 잘 들어간 것
+    - DB에 접속한 상태에서 `select \* from admin;` 같은 것으로 쿼리해볼 수 있음
+    - DB에 접속한 상태에서 `\q`로 나올 수 있음
+- PostgreSQL에서 MySQL로 데이터 migration
+  - `npx prisma generate --schema prisma-psql/schema.prisma --allow-no-models`로 PostgreSQL용 Prisma client 생성
+  - `DATABASE_URL="mysql://upnl:password@localhost:3306/upnl_db" DATABASE_URL_PSQL="postgres://upnl:passwd@localhost:5432/postgres" ts-node --compiler-options '{"module":"CommonJS"}' prisma-psql/migration.ts`로 데이터 migration

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ docker-compose down
 
 ## PostgreSQL -> local MySQL DB migration
 
+- 로컬에 `ts-node` 필요
 - 우선 로컬에 PostgreSQL 컨테이너를 하나 띄우고 덤프된 데이터를 집어넣음
   - docker-compose.yml의 `upnl-postgres` 컨테이너를 uncomment하고 실행
   - Postgresql에서 dump된 파일을 `docker/postgres` 폴더 안에 `init.sql`이라는 이름으로 복사하기

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,13 @@ services:
     ports:
       - 3000:3000
 
-  postgres:
-    image: postgres:15.12-alpine
-    container_name: upnl-postgres
-    volumes:
-      - ./docker/postgres:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_USER=upnl
-      - POSTGRES_PASSWORD=passwd
-    ports:
-      - 5432:5432
+  # postgres:
+  #   image: postgres:15.12-alpine
+  #   container_name: upnl-postgres
+  #   volumes:
+  #     - ./docker/postgres:/var/lib/postgresql/data
+  #   environment:
+  #     - POSTGRES_USER=upnl
+  #     - POSTGRES_PASSWORD=passwd
+  #   ports:
+  #     - 5432:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,14 @@ services:
     command: ["sh", "-c", "yarn global add pnpm && pnpm install && pnpm dev"]
     ports:
       - 3000:3000
+
+  postgres:
+    image: postgres:15.12-alpine
+    container_name: upnl-postgres
+    volumes:
+      - ./docker/postgres:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=upnl
+      - POSTGRES_PASSWORD=passwd
+    ports:
+      - 5432:5432

--- a/prisma-psql/migration.ts
+++ b/prisma-psql/migration.ts
@@ -1,0 +1,125 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { PrismaClient as NewPrismaClient } from "../prisma/client";
+import { PrismaClient as OldPrismaClient } from "./client";
+
+(async function () {
+  const oldPrisma = new OldPrismaClient();
+  const newPrisma = new NewPrismaClient();
+
+  // Independent Tables
+
+  const admins = (await oldPrisma.admin.findMany()) as any[];
+  const boards = (await oldPrisma.board.findMany()) as any[];
+  const indexes = (await oldPrisma.index.findMany()) as any[];
+  const tagCounts = (await oldPrisma.tagcount.findMany()) as any[];
+  const terms = (await oldPrisma.term.findMany()) as any[];
+  const users = (await oldPrisma.user.findMany()) as any[];
+  const workshops = (await oldPrisma.workshop.findMany()) as any[];
+
+  for (const board of boards) {
+    board.no = board.bbs_url;
+    delete board.bbs_url;
+    board.name = board.bbs_name;
+    delete board.bbs_name;
+  }
+  for (const user of users) {
+    user.want_to_do = user.wanttodo;
+    delete user.wanttodo;
+  }
+
+  await newPrisma.admin.createMany({ data: admins });
+  await newPrisma.board.createMany({ data: boards });
+  await newPrisma.index.createMany({ data: indexes });
+  await newPrisma.tagCount.createMany({ data: tagCounts });
+  await newPrisma.term.createMany({ data: terms });
+  await newPrisma.user.createMany({ data: users });
+  await newPrisma.workshop.createMany({ data: workshops });
+
+  // Dependent Level 1 Tables
+
+  const articles = (await oldPrisma.article.findMany()) as any[];
+  const projects = (await oldPrisma.project.findMany()) as any[];
+  const promotes = (await oldPrisma.promote.findMany()) as any[];
+  const sessions = (await oldPrisma.sessions.findMany()) as any[];
+  const studies = (await oldPrisma.study.findMany()) as any[];
+  const tags = (await oldPrisma.tag.findMany()) as any[];
+
+  for (const article of articles) {
+    article.board_no = article.bbs_url;
+    delete article.bbs_url;
+    article.board_name = article.bbs_name;
+    delete article.bbs_name;
+  }
+  for (const project of projects) {
+    project.board_no = project.bbs_url;
+    delete project.bbs_url;
+  }
+  for (const promote of promotes) {
+    promote.board_no = promote.bbs_url;
+    delete promote.bbs_url;
+  }
+  for (const study of studies) {
+    study.board_no = study.bbs_url;
+    delete study.bbs_url;
+  }
+  const tagNoList = tagCounts.map((tagCount) => tagCount.no);
+  const filteredTags = tags.filter((tag) => tagNoList.includes(tag.no));
+
+  await newPrisma.article.createMany({ data: articles });
+  await newPrisma.project.createMany({ data: projects });
+  await newPrisma.promote.createMany({ data: promotes });
+  await newPrisma.sessions.createMany({ data: sessions });
+  await newPrisma.study.createMany({ data: studies });
+  await newPrisma.tag.createMany({ data: filteredTags });
+
+  // Dependent Level 2 Tables
+
+  const comments = (await oldPrisma.comment.findMany()) as any[];
+  const files = (await oldPrisma.file.findMany()) as any[];
+  const panoramas = (await oldPrisma.panorama.findMany()) as any[];
+  const purchases = (await oldPrisma.purchase.findMany()) as any[];
+
+  await newPrisma.comment.createMany({ data: comments });
+  await newPrisma.file.createMany({ data: files });
+  await newPrisma.panorama.createMany({ data: panoramas });
+  await newPrisma.purchase.createMany({ data: purchases });
+
+  // Implicit many-to-many relation tables
+
+  const userProjectLinks = await oldPrisma.user_project_link.findMany();
+  const userPromoteLinks = await oldPrisma.user_promote_link.findMany();
+  const userPurchaseLinks = await oldPrisma.user_purchase_link.findMany();
+  const userStudyLinks = await oldPrisma.user_study_link.findMany();
+  const userWorkshopLinks = await oldPrisma.user_workshop_link.findMany();
+
+  for (const link of userProjectLinks) {
+    await newPrisma.user.update({
+      where: { no: link.user_id },
+      data: { projects_participated: { connect: [{ no: link.project_id }] } },
+    });
+  }
+  for (const link of userPromoteLinks) {
+    await newPrisma.user.update({
+      where: { no: link.user_id },
+      data: { promotes_assented: { connect: [{ no: link.request_id }] } },
+    });
+  }
+  for (const link of userPurchaseLinks) {
+    await newPrisma.user.update({
+      where: { no: link.user_id },
+      data: { purchases_assented: { connect: [{ no: link.request_id }] } },
+    });
+  }
+  for (const link of userStudyLinks) {
+    await newPrisma.user.update({
+      where: { no: link.user_id },
+      data: { studies_participated: { connect: [{ no: link.study_id }] } },
+    });
+  }
+  for (const link of userWorkshopLinks) {
+    await newPrisma.user.update({
+      where: { no: link.user_id },
+      data: { workshops_participated: { connect: [{ no: link.workshop_id }] } },
+    });
+  }
+})();

--- a/prisma-psql/schema.prisma
+++ b/prisma-psql/schema.prisma
@@ -1,0 +1,242 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
+// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
+
+generator client {
+  provider      = "prisma-client-js"
+  output        = "./client"
+  binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+model admin {
+  id       Int       @id @default(autoincrement())
+  name     String    @db.VarChar(20)
+  period   DateTime?
+  year     Int?
+  semester String?   @db.VarChar(20)
+}
+
+model article {
+  no            Int      @id @default(autoincrement())
+  title         String   @db.VarChar(255)
+  content       String   @db.Text
+  date          DateTime
+  writer_id     Int
+  writer_name   String   @db.VarChar(20)
+  board_no      String   @db.VarChar(20) // add foreign key?
+  board_name    String   @db.VarChar(20)
+  images_on_top Boolean
+  is_notice     Boolean
+  render_type   String   @default("markdown") @db.VarChar(20) // markdown, html, html+autobr
+
+  writer    user       @relation(fields: [writer_id], references: [no])
+  comments  comment[]
+  files     file[]
+  panoramas panorama[]
+  purchase  purchase?
+}
+
+model board {
+  no       Int    @id @default(autoincrement())
+  name     String @db.VarChar(20)
+  position Int
+
+  projects project[]
+}
+
+model comment {
+  no          Int      @id @default(autoincrement())
+  content     String   @db.Text
+  date        DateTime
+  writer_id   Int
+  writer_name String   @db.VarChar(20)
+  article_id  Int
+
+  writer  user    @relation(fields: [writer_id], references: [no])
+  article article @relation(fields: [article_id], references: [no])
+}
+
+model file {
+  no              Int    @id @default(autoincrement())
+  s_name          String @db.VarChar(255)
+  filename        String @db.VarChar(255)
+  target_category Int // 파일이 첨부되어 있는 위치(1 : 게시글, 2 : 프로젝트페이지)
+  article_id      Int? // target_category = 2 이면 null
+  project_id      Int? // target_category = 1 이면 null
+
+  article article? @relation(fields: [article_id], references: [no])
+  project project? @relation(fields: [project_id], references: [no])
+}
+
+model index {
+  id      Int    @id @default(autoincrement())
+  content String @db.Text
+}
+
+model panorama {
+  id         Int      @id @default(autoincrement())
+  date       DateTime @map("date")
+  actor_id   Int
+  article_id Int
+  action     Int // 파노라마 항목 분류(1 : 새 게시글, 2 : 새 댓글)
+
+  actor   user    @relation(fields: [actor_id], references: [no])
+  article article @relation(fields: [article_id], references: [no])
+
+  @@index([date])
+}
+
+model project {
+  no           Int       @id @default(autoincrement())
+  name         String    @db.VarChar(255)
+  genre        String    @db.VarChar(255)
+  is_public    Boolean
+  introduction String    @db.Text
+  thumbnail    String    @db.VarChar(255)
+  status       String    @default("working") @db.VarChar(20)
+  board_no     Int
+  orderer_id   Int
+  start_date   DateTime
+  finish_date  DateTime?
+  detail       String?   @db.Text
+  executable   String?   @db.VarChar(255)
+  is_show_page Boolean? // change null to False
+
+  board        board  @relation(fields: [board_no], references: [no])
+  orderer      user   @relation(fields: [orderer_id], references: [no])
+  participants user[] @relation("user_project_link")
+  files        file[]
+}
+
+model promote {
+  no             Int    @id @default(autoincrement())
+  requester_id   Int
+  requester_name String @db.VarChar(20)
+  board_no       Int // add foreign key?
+  start_year     Int
+  start_semester String @db.VarChar(20)
+
+  requester user   @relation(fields: [requester_id], references: [no])
+  assenter  user[] @relation("user_promote_link")
+}
+
+model purchase {
+  no             Int     @id @default(autoincrement())
+  product_name   String  @db.VarChar(255)
+  about          String  @db.VarChar(200)
+  url            String  @db.VarChar(255)
+  article_id     Int     @unique
+  start_year     Int
+  start_semester String  @db.VarChar(20)
+  is_complete    Boolean
+  requester      String  @db.VarChar(20) // add foreign key?
+
+  assenter user[]  @relation("user_purchase_link")
+  article  article @relation(fields: [article_id], references: [no])
+}
+
+model sessions {
+  no             Int     @id @default(autoincrement())
+  title          String? @db.VarChar(255)
+  introduction   String? @db.Text
+  public_level   Int?
+  s_filename     String? @db.VarChar(255)
+  filename       String? @db.VarChar(255)
+  workshop_id    Int
+  presenter_id   Int?
+  presenter_name String  @db.VarChar(20)
+  present_order  Int
+
+  workshop  workshop @relation(fields: [workshop_id], references: [no])
+  presenter user?    @relation(fields: [presenter_id], references: [no])
+}
+
+model study {
+  no           Int       @id @default(autoincrement())
+  name         String    @db.VarChar(255)
+  introduction String    @db.Text
+  status       String    @default("working") @db.VarChar(20)
+  board_no     Int // add foreign key?
+  start_date   DateTime
+  finish_date  DateTime?
+  orderer_id   Int
+
+  orderer      user   @relation(fields: [orderer_id], references: [no])
+  participants user[] @relation("user_study_link")
+}
+
+model tag {
+  no              Int     @id @default(autoincrement())
+  content         String  @db.VarChar(255)
+  tagger_id       Int
+  tagger_name     String  @db.VarChar(20)
+  target_category Int // 태그 대상의 종류(1 : 게시글, 2 : 프로젝트, 3 : 스터디, 4 : 워크샵)
+  target_id       Int
+  is_public       Boolean
+  base_id         Int
+
+  tagger   user     @relation(fields: [tagger_id], references: [no])
+  base_tag tagCount @relation(fields: [base_id], references: [no])
+}
+
+model tagCount {
+  no      Int    @id @default(autoincrement())
+  content String @db.VarChar(255)
+  count   Int    @default(1)
+
+  tags tag[]
+}
+
+model term {
+  id      Int    @id @default(autoincrement())
+  content String @db.Text
+}
+
+model user {
+  no           Int     @id @default(autoincrement())
+  id           String  @unique @db.VarChar(20)
+  passwd       String  @db.VarChar(128)
+  name         String  @db.VarChar(20)
+  email        String  @db.VarChar(50)
+  email_public Boolean
+  phone        String  @db.VarChar(20)
+  phone_public Boolean
+  year         Int? // fill in null and zero
+  dept         String  @db.VarChar(50)
+  level        String  @db.VarChar(10)
+  theme        String  @default("default") @db.VarChar(20)
+  want_to_do   String  @db.Text
+  profile      String? @db.Text // change null to empty string
+
+  articles           article[]
+  sessions           sessions[]
+  comments           comment[]
+  panoramas          panorama[]
+  projects_ordered   project[]
+  promotes_requested promote[]
+  studies_ordered    study[]
+  tags               tag[]
+
+  projects_participated  project[]  @relation("user_project_link")
+  studies_participated   study[]    @relation("user_study_link")
+  promotes_assented      promote[]  @relation("user_promote_link")
+  workshops_participated workshop[] @relation("user_workshop_link")
+  purchases_assented     purchase[] @relation("user_purchase_link")
+}
+
+model workshop {
+  no         Int      @id @default(autoincrement())
+  nth        Int      @unique
+  place      String   @db.VarChar(20)
+  start_date DateTime
+
+  sessions     sessions[]
+  participants user[]     @relation("user_workshop_link")
+}

--- a/prisma-psql/schema.prisma
+++ b/prisma-psql/schema.prisma
@@ -11,8 +11,8 @@ generator client {
 }
 
 datasource db {
-  provider = "mysql"
-  url      = env("DATABASE_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL_PSQL")
 }
 
 model admin {
@@ -30,25 +30,17 @@ model article {
   date          DateTime
   writer_id     Int
   writer_name   String   @db.VarChar(20)
-  board_no      String   @db.VarChar(20) // add foreign key?
-  board_name    String   @db.VarChar(20)
+  bbs_url       String   @db.VarChar(20) // renamed
+  bbs_name      String   @db.VarChar(20) // renamed
   images_on_top Boolean
   is_notice     Boolean
-  render_type   String   @default("markdown") @db.VarChar(20) // markdown, html, html+autobr
-
-  writer    user       @relation(fields: [writer_id], references: [no])
-  comments  comment[]
-  files     file[]
-  panoramas panorama[]
-  purchase  purchase?
+  render_type   String   @default("markdown") @db.VarChar(20)
 }
 
 model board {
-  no       Int    @id @default(autoincrement())
-  name     String @db.VarChar(20)
+  bbs_url  Int    @id @default(autoincrement()) // renamed
+  bbs_name String @db.VarChar(20) // renamed
   position Int
-
-  projects project[]
 }
 
 model comment {
@@ -58,21 +50,15 @@ model comment {
   writer_id   Int
   writer_name String   @db.VarChar(20)
   article_id  Int
-
-  writer  user    @relation(fields: [writer_id], references: [no])
-  article article @relation(fields: [article_id], references: [no])
 }
 
 model file {
   no              Int    @id @default(autoincrement())
   s_name          String @db.VarChar(255)
   filename        String @db.VarChar(255)
-  target_category Int // 파일이 첨부되어 있는 위치(1 : 게시글, 2 : 프로젝트페이지)
-  article_id      Int? // target_category = 2 이면 null
-  project_id      Int? // target_category = 1 이면 null
-
-  article article? @relation(fields: [article_id], references: [no])
-  project project? @relation(fields: [project_id], references: [no])
+  target_category Int
+  article_id      Int?
+  project_id      Int?
 }
 
 model index {
@@ -85,12 +71,7 @@ model panorama {
   date       DateTime @map("date")
   actor_id   Int
   article_id Int
-  action     Int // 파노라마 항목 분류(1 : 새 게시글, 2 : 새 댓글)
-
-  actor   user    @relation(fields: [actor_id], references: [no])
-  article article @relation(fields: [article_id], references: [no])
-
-  @@index([date])
+  action     Int
 }
 
 model project {
@@ -101,30 +82,22 @@ model project {
   introduction String    @db.Text
   thumbnail    String    @db.VarChar(255)
   status       String    @default("working") @db.VarChar(20)
-  board_no     Int
+  bbs_url      Int // renamed
   orderer_id   Int
   start_date   DateTime
   finish_date  DateTime?
   detail       String?   @db.Text
   executable   String?   @db.VarChar(255)
-  is_show_page Boolean? // change null to False
-
-  board        board  @relation(fields: [board_no], references: [no])
-  orderer      user   @relation(fields: [orderer_id], references: [no])
-  participants user[] @relation("user_project_link")
-  files        file[]
+  is_show_page Boolean?
 }
 
 model promote {
   no             Int    @id @default(autoincrement())
   requester_id   Int
   requester_name String @db.VarChar(20)
-  board_no       Int // add foreign key?
+  bbs_url        Int // renamed
   start_year     Int
   start_semester String @db.VarChar(20)
-
-  requester user   @relation(fields: [requester_id], references: [no])
-  assenter  user[] @relation("user_promote_link")
 }
 
 model purchase {
@@ -136,10 +109,7 @@ model purchase {
   start_year     Int
   start_semester String  @db.VarChar(20)
   is_complete    Boolean
-  requester      String  @db.VarChar(20) // add foreign key?
-
-  assenter user[]  @relation("user_purchase_link")
-  article  article @relation(fields: [article_id], references: [no])
+  requester      String  @db.VarChar(20)
 }
 
 model sessions {
@@ -153,9 +123,6 @@ model sessions {
   presenter_id   Int?
   presenter_name String  @db.VarChar(20)
   present_order  Int
-
-  workshop  workshop @relation(fields: [workshop_id], references: [no])
-  presenter user?    @relation(fields: [presenter_id], references: [no])
 }
 
 model study {
@@ -163,13 +130,10 @@ model study {
   name         String    @db.VarChar(255)
   introduction String    @db.Text
   status       String    @default("working") @db.VarChar(20)
-  board_no     Int // add foreign key?
+  bbs_url      Int // renamed
   start_date   DateTime
   finish_date  DateTime?
   orderer_id   Int
-
-  orderer      user   @relation(fields: [orderer_id], references: [no])
-  participants user[] @relation("user_study_link")
 }
 
 model tag {
@@ -177,21 +141,16 @@ model tag {
   content         String  @db.VarChar(255)
   tagger_id       Int
   tagger_name     String  @db.VarChar(20)
-  target_category Int // 태그 대상의 종류(1 : 게시글, 2 : 프로젝트, 3 : 스터디, 4 : 워크샵)
+  target_category Int
   target_id       Int
   is_public       Boolean
   base_id         Int
-
-  tagger   user     @relation(fields: [tagger_id], references: [no])
-  base_tag tagCount @relation(fields: [base_id], references: [no])
 }
 
-model tagCount {
+model tagcount {
   no      Int    @id @default(autoincrement())
   content String @db.VarChar(255)
   count   Int    @default(1)
-
-  tags tag[]
 }
 
 model term {
@@ -208,27 +167,42 @@ model user {
   email_public Boolean
   phone        String  @db.VarChar(20)
   phone_public Boolean
-  year         Int? // fill in null and zero
+  year         Int?
   dept         String  @db.VarChar(50)
   level        String  @db.VarChar(10)
   theme        String  @default("default") @db.VarChar(20)
-  want_to_do   String  @db.Text
-  profile      String? @db.Text // change null to empty string
+  wanttodo     String  @db.Text // renamed
+  profile      String? @db.Text
+}
 
-  articles           article[]
-  sessions           sessions[]
-  comments           comment[]
-  panoramas          panorama[]
-  projects_ordered   project[]
-  promotes_requested promote[]
-  studies_ordered    study[]
-  tags               tag[]
+model user_project_link {
+  no         Int @id @default(autoincrement())
+  user_id    Int
+  project_id Int
+}
 
-  projects_participated  project[]  @relation("user_project_link")
-  studies_participated   study[]    @relation("user_study_link")
-  promotes_assented      promote[]  @relation("user_promote_link")
-  workshops_participated workshop[] @relation("user_workshop_link")
-  purchases_assented     purchase[] @relation("user_purchase_link")
+model user_promote_link {
+  no         Int @id @default(autoincrement())
+  user_id    Int
+  request_id Int
+}
+
+model user_purchase_link {
+  no         Int @id @default(autoincrement())
+  user_id    Int
+  request_id Int
+}
+
+model user_study_link {
+  no       Int @id @default(autoincrement())
+  user_id  Int
+  study_id Int
+}
+
+model user_workshop_link {
+  no          Int @id @default(autoincrement())
+  user_id     Int
+  workshop_id Int
 }
 
 model workshop {
@@ -236,7 +210,4 @@ model workshop {
   nth        Int      @unique
   place      String   @db.VarChar(20)
   start_date DateTime
-
-  sessions     sessions[]
-  participants user[]     @relation("user_workshop_link")
 }

--- a/prisma/migrations/20250527095900_theme_length/migration.sql
+++ b/prisma/migrations/20250527095900_theme_length/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `user` MODIFY `theme` VARCHAR(256) NOT NULL DEFAULT 'default';

--- a/prisma/migrations/20250527112646_longtext/migration.sql
+++ b/prisma/migrations/20250527112646_longtext/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE `article` MODIFY `content` LONGTEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE `index` MODIFY `content` LONGTEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,7 +211,7 @@ model user {
   year         Int? // fill in null and zero
   dept         String  @db.VarChar(50)
   level        String  @db.VarChar(10)
-  theme        String  @default("default") @db.VarChar(20)
+  theme        String  @default("default") @db.VarChar(256)
   want_to_do   String  @db.Text
   profile      String? @db.Text // change null to empty string
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,7 +26,7 @@ model admin {
 model article {
   no            Int      @id @default(autoincrement())
   title         String   @db.VarChar(255)
-  content       String   @db.Text
+  content       String   @db.LongText
   date          DateTime
   writer_id     Int
   writer_name   String   @db.VarChar(20)
@@ -77,7 +77,7 @@ model file {
 
 model index {
   id      Int    @id @default(autoincrement())
-  content String @db.Text
+  content String @db.LongText
 }
 
 model panorama {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     "**/*.tsx",
     ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "prisma-psql"]
 }


### PR DESCRIPTION
- 기존에 PostgreSQL에 있던 데이터를 MySQL로 가져오는 작업
  - 로컬에 PostgreSQL 컨테이너를 하나 띄워 덤프된 데이터를 집어넣음
  - 로컬의 PostgreSQL DB에 접속할 수 있는 Prisma Client를 만듦
  - migration script를 만들어, PostgreSQL DB에 접근해서 데이터를 가져오고, 가공해서 MySQL DB에 데이터를 추가함
  - migration 방법을 README.md에 작성
- MySQL 테이블 일부 수정
  - VARCHAR 길이 수정
  - column type을 TEXT -> LONGTEXT 변경